### PR TITLE
Switch from FOUNDRY_FF_ENHANCED_UI to FOUNDRY_UI_HEADLESS_MODE

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,8 +157,8 @@ foundry profile activate --name <name>     # Switch between environments
 # App Development Lifecycle
 foundry apps create --name "X" --no-prompt --no-git  # Create new app
 foundry apps run                           # Start full app locally in dev mode
-FOUNDRY_FF_ENHANCED_UI=false foundry apps deploy --change-type Patch --change-log "msg" --no-prompt  # Deploy to cloud
-FOUNDRY_FF_ENHANCED_UI=false foundry apps release --change-type Patch --deployment-id <id> --notes "notes"  # Release to app catalog
+foundry apps deploy --change-type Patch --change-log "msg" --no-prompt  # Deploy to cloud
+foundry apps release --change-type Patch --deployment-id <id> --notes "notes"  # Release to app catalog
 foundry ui run                             # Local UI development server
 
 # Scaffolding Commands (ALWAYS use --no-prompt)

--- a/hooks/foundry-cli-guard.sh
+++ b/hooks/foundry-cli-guard.sh
@@ -11,7 +11,9 @@
 # 2. Running ui extensions create without --sockets (interactive picker hangs)
 # 3. Using mkdir/touch to create app structure (causes invalid manifests)
 # 4. Creating resources without user confirmation of the name
-# 5. Running deploy/release/list-deployments without FOUNDRY_FF_ENHANCED_UI=false (TUI hangs)
+# 5. Running deploy/release/list-deployments without FOUNDRY_UI_HEADLESS_MODE=true (TUI hangs)
+#    Note: The SessionStart hook (set-foundry-env.sh) sets this env var automatically.
+#    This guard is a fallback for edge cases where the env var isn't set.
 #
 # Receives JSON on stdin with hook_event_name and tool-specific fields.
 # Outputs JSON with additionalContext (advisory nudge, not blocking).
@@ -94,16 +96,16 @@ if echo "$COMMAND" | grep -qE 'foundry\s+ui\s+extensions\b.*\bcreate\b'; then
   fi
 fi
 
-# Check for foundry apps deploy/release/list-deployments without FOUNDRY_FF_ENHANCED_UI=false
+# Check for foundry apps deploy/release/list-deployments without FOUNDRY_UI_HEADLESS_MODE=true
+# Normally the SessionStart hook sets this env var, but this guard catches edge cases.
 # The enhanced UI (TUI progress monitor) requires a TTY and hangs in non-interactive environments.
-# Some developers set FOUNDRY_FF_ENHANCED_UI=true; future CLI versions may default to true.
-# Skip advisory only when the env var is explicitly "false" — unset or "true" both need the prefix.
+# Skip advisory only when the env var is explicitly "true" — unset or "false" both need the prefix.
 if echo "$COMMAND" | grep -qE 'foundry\s+apps\s+(deploy|release|list-deployments)\b'; then
-  if [ "${FOUNDRY_FF_ENHANCED_UI:-}" != "false" ] && ! echo "$COMMAND" | grep -qF 'FOUNDRY_FF_ENHANCED_UI=false'; then
+  if [ "${FOUNDRY_UI_HEADLESS_MODE:-}" != "true" ] && ! echo "$COMMAND" | grep -qF 'FOUNDRY_UI_HEADLESS_MODE=true'; then
     jq -n '{
       hookSpecificOutput: {
         hookEventName: "PreToolUse",
-        additionalContext: "The command is missing FOUNDRY_FF_ENHANCED_UI=false. The enhanced UI (TUI progress monitor) requires a TTY and will hang in Claude Code. Prepend FOUNDRY_FF_ENHANCED_UI=false to the command. Example: FOUNDRY_FF_ENHANCED_UI=false foundry apps deploy --change-type Patch --change-log \"msg\""
+        additionalContext: "The command is missing FOUNDRY_UI_HEADLESS_MODE=true. The enhanced UI (TUI progress monitor) requires a TTY and will hang in Claude Code. Prepend FOUNDRY_UI_HEADLESS_MODE=true to the command. Example: FOUNDRY_UI_HEADLESS_MODE=true foundry apps deploy --change-type Patch --change-log \"msg\""
       }
     }'
     exit 0

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/set-foundry-env.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "UserPromptSubmit": [
       {
         "hooks": [

--- a/hooks/set-foundry-env.sh
+++ b/hooks/set-foundry-env.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# set-foundry-env.sh — SessionStart hook
+#
+# Sets FOUNDRY_UI_HEADLESS_MODE=true for the entire session so that
+# deploy, release, and list-deployments commands work without a TTY.
+# This eliminates the need to prefix each command manually.
+#
+set -euo pipefail
+
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+  echo 'export FOUNDRY_UI_HEADLESS_MODE=true' >> "$CLAUDE_ENV_FILE"
+fi
+
+exit 0

--- a/skills/foundry-development-workflow/SKILL.md
+++ b/skills/foundry-development-workflow/SKILL.md
@@ -30,13 +30,8 @@ metadata:
 >
 > **CRITICAL: `--no-prompt` is supported by nearly all commands.** Always add `--no-prompt` to prevent interactive prompts that cause `Error: EOF` in non-interactive environments. Supported commands include: `apps create`, `apps deploy`, `apps release`, `apps delete` (also needs `--force-delete`, but may still prompt interactively in some CLI versions — delete via Falcon App Manager UI if it hangs), `functions create`, `collections create`, `ui pages create`, `ui extensions create`, `rtr-scripts create`, `profile create`, `workflows create`, and `api-integrations create`. When unsure, run `foundry <command> --help` to check. When a CLI command fails, MUST NOT fall back to `mkdir` — fix the command and retry.
 >
-> **CRITICAL: `FOUNDRY_FF_ENHANCED_UI=false` is required for non-TTY environments.**
-> The enhanced UI (TUI progress monitor) requires a TTY and will hang or fail in Claude Code, CI/CD pipelines, and headless environments. **Always prepend `FOUNDRY_FF_ENHANCED_UI=false` to these commands:**
-> - `foundry apps deploy`
-> - `foundry apps release`
-> - `foundry apps list-deployments`
->
-> Example: `FOUNDRY_FF_ENHANCED_UI=false foundry apps deploy --change-type Patch --change-log "msg"`
+> **NOTE: `FOUNDRY_UI_HEADLESS_MODE=true` is set automatically** by the plugin's SessionStart hook.
+> You do not need to prefix `deploy`, `release`, or `list-deployments` commands with it.
 >
 > **Superpowers skills MAY supplement** (TDD discipline, code review) but MUST NOT replace this workflow.
 
@@ -127,7 +122,7 @@ foundry api-integrations create --name "MyApi" --description "desc" --spec /tmp/
 foundry collections create --name "my_col" --schema /tmp/my_schema.json --description "desc" --no-prompt
 
 # 3. DEPLOY EARLY — fail fast if specs or schemas are bad
-FOUNDRY_FF_ENHANCED_UI=false foundry apps deploy --no-prompt --change-type Patch --change-log "Backend capabilities"
+foundry apps deploy --no-prompt --change-type Patch --change-log "Backend capabilities"
 # Poll with list-deployments — if still in progress, sleep 5 and retry
 # If deploy fails, STOP. Fix the spec/schema — do not build UI on a broken backend.
 # The adapt script should handle spec issues. If it didn't, improve the script.
@@ -166,12 +161,12 @@ The CLI scaffolds structure but cannot generate app logic. Delegate to sub-skill
 cd ui/pages/my-page && npm install && npm run build && cd ../../..
 
 # Final deploy (run ONCE, never re-deploy to check status)
-FOUNDRY_FF_ENHANCED_UI=false foundry apps deploy --no-prompt --change-type Patch --change-log "Complete app"
+foundry apps deploy --no-prompt --change-type Patch --change-log "Complete app"
 
 # Poll deployment status — run immediately, do NOT prepend sleep
-FOUNDRY_FF_ENHANCED_UI=false foundry apps list-deployments
+foundry apps list-deployments
 # If still in progress, wait 5s then poll again:
-# sleep 5 && FOUNDRY_FF_ENHANCED_UI=false foundry apps list-deployments
+# sleep 5 && foundry apps list-deployments
 
 # Local UI development (deploy first if UI calls backend capabilities)
 foundry ui run
@@ -181,7 +176,7 @@ foundry ui run
 
 ```bash
 # Release (run ONCE after deploy succeeds)
-FOUNDRY_FF_ENHANCED_UI=false foundry apps release --change-type Patch --deployment-id <id> --notes "Release notes"
+foundry apps release --change-type Patch --deployment-id <id> --notes "Release notes"
 ```
 
 **Note:** There is no `list-releases` command. After `release`, check status via the App Manager URL printed in the output, or wait ~30s and proceed to testing.
@@ -215,7 +210,7 @@ To deploy the same app to multiple clouds (US-1, US-2, EU-1, etc.):
 
 When `manifest.yml` already exists, work is primarily editing existing files. Use CLI only for:
 - `foundry apps run` / `foundry ui run` — local development
-- `FOUNDRY_FF_ENHANCED_UI=false foundry apps deploy` / `FOUNDRY_FF_ENHANCED_UI=false foundry apps release` — deployment
+- `foundry apps deploy` / `foundry apps release` — deployment
 - `foundry api-integrations create` etc. — adding new capabilities
 
 ## Testing an Existing App Locally
@@ -225,11 +220,11 @@ When running e2e tests against an existing app:
 1. **Update manifest name** if needed (to match `APP_NAME` in `e2e/.env`)
 2. **Deploy and release:**
    ```bash
-   FOUNDRY_FF_ENHANCED_UI=false foundry apps deploy --change-type patch --change-log "e2e testing" --no-prompt
+   foundry apps deploy --change-type patch --change-log "e2e testing" --no-prompt
    # Poll until successful
-   FOUNDRY_FF_ENHANCED_UI=false foundry apps list-deployments
+   foundry apps list-deployments
    # Release
-   FOUNDRY_FF_ENHANCED_UI=false foundry apps release --deployment-id <id> --change-type patch --notes "e2e testing" --no-prompt
+   foundry apps release --deployment-id <id> --change-type patch --notes "e2e testing" --no-prompt
    ```
 3. **Run tests:** `cd e2e && npx playwright test`
 4. **Revert manifest:** `git checkout manifest.yml` (deploy writes IDs into the manifest)

--- a/skills/foundry-development-workflow/references/headless-operation.md
+++ b/skills/foundry-development-workflow/references/headless-operation.md
@@ -55,8 +55,8 @@ Commands that prompt for user input support `--no-prompt` to suppress prompts an
 |---------|---------------------|
 | `foundry apps create` | `foundry apps create --name "app" --description "desc" --no-prompt --no-git` |
 | `foundry apps delete` | `foundry apps delete --force-delete --no-prompt` |
-| `foundry apps deploy` | `FOUNDRY_FF_ENHANCED_UI=false foundry apps deploy --change-type minor --change-log "description" --no-prompt` |
-| `foundry apps release` | `FOUNDRY_FF_ENHANCED_UI=false foundry apps release --deployment-id <id> --change-type minor --notes "notes"` |
+| `foundry apps deploy` | `foundry apps deploy --change-type minor --change-log "description" --no-prompt` |
+| `foundry apps release` | `foundry apps release --deployment-id <id> --change-type minor --notes "notes"` |
 | `foundry profile create` | `foundry profile create --name <n> --api-client-id <id> --api-client-secret <s> --cid <c> --cloud-region <r> --no-prompt` |
 | `foundry profile activate` | `foundry profile activate --name "profile-name"` |
 | `foundry profile delete` | `foundry profile delete --name "profile-name" --no-prompt` |
@@ -85,12 +85,12 @@ Error: could not open a new TTY: open /dev/tty: device not configured
 
 or hang and produce garbled output.
 
-**Fix: Always prepend `FOUNDRY_FF_ENHANCED_UI=false`** to commands that trigger the TUI:
+**Fix:** The plugin's SessionStart hook sets `FOUNDRY_UI_HEADLESS_MODE=true` automatically for all Bash commands. If running outside the plugin (CI/CD, scripts), set the env var manually:
 
 ```bash
-FOUNDRY_FF_ENHANCED_UI=false foundry apps deploy --change-type Patch --change-log "description"
-FOUNDRY_FF_ENHANCED_UI=false foundry apps release --deployment-id <id> --change-type Patch --notes "notes"
-FOUNDRY_FF_ENHANCED_UI=false foundry apps list-deployments
+foundry apps deploy --change-type Patch --change-log "description"
+foundry apps release --deployment-id <id> --change-type Patch --notes "notes"
+foundry apps list-deployments
 ```
 
 This disables the TUI progress monitor and falls back to plain text output suitable for non-interactive environments.
@@ -115,7 +115,7 @@ When operating as a CLI agent:
 3. **Never run `foundry login` without user confirmation:** The browser flow will hang in headless environments
 4. **Always pass all required flags:** Never rely on interactive prompts — always include `--no-prompt` where supported
 5. **Use `--no-git` on `foundry apps create`:** Prevents git init prompts in environments where git may not be configured
-6. **Prepend `FOUNDRY_FF_ENHANCED_UI=false`** to `deploy`, `release`, and `list-deployments` commands to disable the TUI progress monitor
+6. **`FOUNDRY_UI_HEADLESS_MODE=true`** is set automatically by the plugin's SessionStart hook. For standalone scripts/CI, export it manually.
 
 ## Counter-Rationalizations for Interactive Mode
 

--- a/skills/foundry-ui-development/references/advanced-patterns.md
+++ b/skills/foundry-ui-development/references/advanced-patterns.md
@@ -40,7 +40,7 @@
 
 ```bash
 # For apps with backend dependencies: deploy first, then iterate on UI
-FOUNDRY_FF_ENHANCED_UI=false foundry apps deploy --change-type Patch --change-log "Initial deployment" --no-prompt
+foundry apps deploy --change-type Patch --change-log "Initial deployment" --no-prompt
 foundry ui run
 
 # For pure UI work (no API integration/collection/function calls): no deploy needed

--- a/test-hooks.sh
+++ b/test-hooks.sh
@@ -3,8 +3,9 @@
 # test-hooks.sh — Unit tests for hook scripts
 #
 # Tests foundry-skill-router.sh (UserPromptSubmit + PreToolUse),
-# superpowers-foundry-bridge.sh (Skill interception), and
-# foundry-cli-guard.sh (--no-prompt enforcement).
+# superpowers-foundry-bridge.sh (Skill interception),
+# foundry-cli-guard.sh (--no-prompt enforcement), and
+# set-foundry-env.sh (SessionStart env injection).
 #
 # Usage: ./test-hooks.sh
 #
@@ -917,7 +918,7 @@ assert_empty "$OUTPUT" "6.2  apps create with --no-prompt → pass"
 # 6.3 — foundry apps deploy (no --no-prompt needed) → no output
 # deploy works non-interactively when --change-type/--change-log are provided
 cleanup
-JSON=$(jq -n '{hook_event_name: "PreToolUse", tool_name: "Bash", tool_input: {command: "FOUNDRY_FF_ENHANCED_UI=false foundry apps deploy --change-type Patch --change-log \"bugfix\""}}')
+JSON=$(jq -n '{hook_event_name: "PreToolUse", tool_name: "Bash", tool_input: {command: "FOUNDRY_UI_HEADLESS_MODE=true foundry apps deploy --change-type Patch --change-log \"bugfix\""}}')
 OUTPUT=$(run_hook "$GUARD" "$JSON")
 assert_empty "$OUTPUT" "6.3  apps deploy → pass (no --no-prompt needed)"
 
@@ -973,7 +974,7 @@ assert_empty "$OUTPUT" "6.11 foundry login → pass (no --no-prompt needed)"
 # 6.12 — foundry apps release with --no-prompt → no output
 # release requires --no-prompt for non-interactive operation
 cleanup
-JSON=$(jq -n '{hook_event_name: "PreToolUse", tool_name: "Bash", tool_input: {command: "FOUNDRY_FF_ENHANCED_UI=false foundry apps release --deployment-id abc123 --change-type Patch --notes \"initial release\" --no-prompt"}}')
+JSON=$(jq -n '{hook_event_name: "PreToolUse", tool_name: "Bash", tool_input: {command: "FOUNDRY_UI_HEADLESS_MODE=true foundry apps release --deployment-id abc123 --change-type Patch --notes \"initial release\" --no-prompt"}}')
 OUTPUT=$(run_hook "$GUARD" "$JSON")
 assert_empty "$OUTPUT" "6.12 apps release with --no-prompt → pass"
 
@@ -1031,49 +1032,49 @@ JSON=$(jq -n '{hook_event_name: "PreToolUse", tool_name: "Bash", tool_input: {co
 OUTPUT=$(FOUNDRY_SKIP_NAME_CONFIRM=1 run_hook "$GUARD" "$JSON")
 assert_empty "$OUTPUT" "6.18c valid socket xdr.cases.panel → pass"
 
-printf "\n${BOLD}Section 6 (cont): CLI Guard — FOUNDRY_FF_ENHANCED_UI Enforcement${RESET}\n\n"
+printf "\n${BOLD}Section 6 (cont): CLI Guard — FOUNDRY_UI_HEADLESS_MODE Enforcement${RESET}\n\n"
 
-# 6.19 — foundry apps deploy without FOUNDRY_FF_ENHANCED_UI=false → advisory
+# 6.19 — foundry apps deploy without FOUNDRY_UI_HEADLESS_MODE=true → advisory
 cleanup
 JSON=$(jq -n '{hook_event_name: "PreToolUse", tool_name: "Bash", tool_input: {command: "foundry apps deploy --change-type Patch --change-log \"bugfix\""}}')
-OUTPUT=$(env -u FOUNDRY_FF_ENHANCED_UI bash -c 'echo "$1" | "$0" 2>/dev/null || true' "$GUARD" "$JSON")
-assert_contains "$OUTPUT" "FOUNDRY_FF_ENHANCED_UI=false" "6.19 deploy without FOUNDRY_FF_ENHANCED_UI → advisory"
+OUTPUT=$(env -u FOUNDRY_UI_HEADLESS_MODE bash -c 'echo "$1" | "$0" 2>/dev/null || true' "$GUARD" "$JSON")
+assert_contains "$OUTPUT" "FOUNDRY_UI_HEADLESS_MODE=true" "6.19 deploy without FOUNDRY_UI_HEADLESS_MODE → advisory"
 
-# 6.20 — foundry apps deploy with inline FOUNDRY_FF_ENHANCED_UI=false (env unset) → pass
+# 6.20 — foundry apps deploy with inline FOUNDRY_UI_HEADLESS_MODE=true (env unset) → pass
 cleanup
-JSON=$(jq -n '{hook_event_name: "PreToolUse", tool_name: "Bash", tool_input: {command: "FOUNDRY_FF_ENHANCED_UI=false foundry apps deploy --change-type Patch --change-log \"bugfix\""}}')
-OUTPUT=$(env -u FOUNDRY_FF_ENHANCED_UI bash -c 'echo "$1" | "$0" 2>/dev/null || true' "$GUARD" "$JSON")
-assert_empty "$OUTPUT" "6.20 deploy with inline FOUNDRY_FF_ENHANCED_UI=false → pass"
+JSON=$(jq -n '{hook_event_name: "PreToolUse", tool_name: "Bash", tool_input: {command: "FOUNDRY_UI_HEADLESS_MODE=true foundry apps deploy --change-type Patch --change-log \"bugfix\""}}')
+OUTPUT=$(env -u FOUNDRY_UI_HEADLESS_MODE bash -c 'echo "$1" | "$0" 2>/dev/null || true' "$GUARD" "$JSON")
+assert_empty "$OUTPUT" "6.20 deploy with inline FOUNDRY_UI_HEADLESS_MODE=true → pass"
 
-# 6.21 — foundry apps deploy with env FOUNDRY_FF_ENHANCED_UI=false → pass (env-aware)
-cleanup
-JSON=$(jq -n '{hook_event_name: "PreToolUse", tool_name: "Bash", tool_input: {command: "foundry apps deploy --change-type Patch --change-log \"bugfix\""}}')
-OUTPUT=$(FOUNDRY_FF_ENHANCED_UI=false run_hook "$GUARD" "$JSON")
-assert_empty "$OUTPUT" "6.21 deploy with env FOUNDRY_FF_ENHANCED_UI=false → pass"
-
-# 6.22 — foundry apps deploy with env FOUNDRY_FF_ENHANCED_UI=true → advisory
+# 6.21 — foundry apps deploy with env FOUNDRY_UI_HEADLESS_MODE=true → pass (env-aware)
 cleanup
 JSON=$(jq -n '{hook_event_name: "PreToolUse", tool_name: "Bash", tool_input: {command: "foundry apps deploy --change-type Patch --change-log \"bugfix\""}}')
-OUTPUT=$(FOUNDRY_FF_ENHANCED_UI=true run_hook "$GUARD" "$JSON")
-assert_contains "$OUTPUT" "FOUNDRY_FF_ENHANCED_UI=false" "6.22 deploy with env FOUNDRY_FF_ENHANCED_UI=true → advisory"
+OUTPUT=$(FOUNDRY_UI_HEADLESS_MODE=true run_hook "$GUARD" "$JSON")
+assert_empty "$OUTPUT" "6.21 deploy with env FOUNDRY_UI_HEADLESS_MODE=true → pass"
 
-# 6.23 — foundry apps release without FOUNDRY_FF_ENHANCED_UI=false → advisory
+# 6.22 — foundry apps deploy with env FOUNDRY_UI_HEADLESS_MODE=false → advisory
+cleanup
+JSON=$(jq -n '{hook_event_name: "PreToolUse", tool_name: "Bash", tool_input: {command: "foundry apps deploy --change-type Patch --change-log \"bugfix\""}}')
+OUTPUT=$(FOUNDRY_UI_HEADLESS_MODE=false run_hook "$GUARD" "$JSON")
+assert_contains "$OUTPUT" "FOUNDRY_UI_HEADLESS_MODE=true" "6.22 deploy with env FOUNDRY_UI_HEADLESS_MODE=false → advisory"
+
+# 6.23 — foundry apps release without FOUNDRY_UI_HEADLESS_MODE=true → advisory
 cleanup
 JSON=$(jq -n '{hook_event_name: "PreToolUse", tool_name: "Bash", tool_input: {command: "foundry apps release --deployment-id abc123 --change-type Patch --notes \"v1\" --no-prompt"}}')
-OUTPUT=$(env -u FOUNDRY_FF_ENHANCED_UI bash -c 'echo "$1" | "$0" 2>/dev/null || true' "$GUARD" "$JSON")
-assert_contains "$OUTPUT" "FOUNDRY_FF_ENHANCED_UI=false" "6.23 release without FOUNDRY_FF_ENHANCED_UI → advisory"
+OUTPUT=$(env -u FOUNDRY_UI_HEADLESS_MODE bash -c 'echo "$1" | "$0" 2>/dev/null || true' "$GUARD" "$JSON")
+assert_contains "$OUTPUT" "FOUNDRY_UI_HEADLESS_MODE=true" "6.23 release without FOUNDRY_UI_HEADLESS_MODE → advisory"
 
-# 6.24 — foundry apps list-deployments without FOUNDRY_FF_ENHANCED_UI=false → advisory
+# 6.24 — foundry apps list-deployments without FOUNDRY_UI_HEADLESS_MODE=true → advisory
 cleanup
 JSON=$(jq -n '{hook_event_name: "PreToolUse", tool_name: "Bash", tool_input: {command: "foundry apps list-deployments"}}')
-OUTPUT=$(env -u FOUNDRY_FF_ENHANCED_UI bash -c 'echo "$1" | "$0" 2>/dev/null || true' "$GUARD" "$JSON")
-assert_contains "$OUTPUT" "FOUNDRY_FF_ENHANCED_UI=false" "6.24 list-deployments without FOUNDRY_FF_ENHANCED_UI → advisory"
+OUTPUT=$(env -u FOUNDRY_UI_HEADLESS_MODE bash -c 'echo "$1" | "$0" 2>/dev/null || true' "$GUARD" "$JSON")
+assert_contains "$OUTPUT" "FOUNDRY_UI_HEADLESS_MODE=true" "6.24 list-deployments without FOUNDRY_UI_HEADLESS_MODE → advisory"
 
-# 6.25 — foundry apps list-deployments with env FOUNDRY_FF_ENHANCED_UI=false → pass
+# 6.25 — foundry apps list-deployments with env FOUNDRY_UI_HEADLESS_MODE=true → pass
 cleanup
 JSON=$(jq -n '{hook_event_name: "PreToolUse", tool_name: "Bash", tool_input: {command: "foundry apps list-deployments"}}')
-OUTPUT=$(FOUNDRY_FF_ENHANCED_UI=false run_hook "$GUARD" "$JSON")
-assert_empty "$OUTPUT" "6.25 list-deployments with env FOUNDRY_FF_ENHANCED_UI=false → pass"
+OUTPUT=$(FOUNDRY_UI_HEADLESS_MODE=true run_hook "$GUARD" "$JSON")
+assert_empty "$OUTPUT" "6.25 list-deployments with env FOUNDRY_UI_HEADLESS_MODE=true → pass"
 
 # =============================================
 # Section 7: Skill Description Validation
@@ -1168,7 +1169,7 @@ assert_empty "$OUTPUT" "8.4  FOUNDRY_SKIP_NAME_CONFIRM=1 → no advisory"
 # 8.5 — foundry apps deploy (no --name) → no confirmation
 cleanup
 JSON=$(jq -n '{hook_event_name: "PreToolUse", tool_name: "Bash", tool_input: {command: "foundry apps deploy --change-type Patch --change-log \"fix\""}}')
-OUTPUT=$(FOUNDRY_FF_ENHANCED_UI=false run_hook "$GUARD" "$JSON")
+OUTPUT=$(FOUNDRY_UI_HEADLESS_MODE=true run_hook "$GUARD" "$JSON")
 assert_empty "$OUTPUT" "8.5  apps deploy → no name confirmation"
 
 # 8.6 — foundry workflows create with --name → name confirmation advisory
@@ -1258,6 +1259,58 @@ JSON=$(jq -n --arg cmd "foundry apps create --name='' --no-prompt" \
   '{hook_event_name: "PreToolUse", tool_name: "Bash", tool_input: {command: $cmd}}')
 OUTPUT=$(run_hook "$GUARD" "$JSON")
 assert_empty "$OUTPUT" "8.18 --name='' (empty) → no confirmation"
+
+# =============================================
+# Section 9: SessionStart Hook — set-foundry-env.sh
+# =============================================
+printf "\n${BOLD}--- Section 9: SessionStart Hook — set-foundry-env.sh ---${RESET}\n\n"
+
+ENV_HOOK="./hooks/set-foundry-env.sh"
+
+# 9.1 — Writes FOUNDRY_UI_HEADLESS_MODE=true to CLAUDE_ENV_FILE
+cleanup
+ENV_TMP=$(mktemp)
+CLAUDE_ENV_FILE="$ENV_TMP" bash "$ENV_HOOK"
+OUTPUT=$(cat "$ENV_TMP")
+TOTAL=$((TOTAL + 1))
+if echo "$OUTPUT" | grep -qF 'export FOUNDRY_UI_HEADLESS_MODE=true'; then
+  PASS=$((PASS + 1))
+  printf "${GREEN}  PASS${RESET} 9.1  writes FOUNDRY_UI_HEADLESS_MODE=true to CLAUDE_ENV_FILE\n"
+else
+  FAIL=$((FAIL + 1))
+  printf "${RED}  FAIL${RESET} 9.1  expected FOUNDRY_UI_HEADLESS_MODE=true in env file, got: %s\n" "$OUTPUT"
+fi
+rm -f "$ENV_TMP"
+
+# 9.2 — Does nothing when CLAUDE_ENV_FILE is unset
+cleanup
+OUTPUT=$(env -u CLAUDE_ENV_FILE bash "$ENV_HOOK" 2>&1)
+TOTAL=$((TOTAL + 1))
+if [ $? -eq 0 ]; then
+  PASS=$((PASS + 1))
+  printf "${GREEN}  PASS${RESET} 9.2  exits cleanly when CLAUDE_ENV_FILE is unset\n"
+else
+  FAIL=$((FAIL + 1))
+  printf "${RED}  FAIL${RESET} 9.2  should exit 0 when CLAUDE_ENV_FILE is unset\n"
+fi
+
+# 9.3 — Appends (does not overwrite) existing env file content
+cleanup
+ENV_TMP=$(mktemp)
+echo 'export EXISTING_VAR=hello' > "$ENV_TMP"
+CLAUDE_ENV_FILE="$ENV_TMP" bash "$ENV_HOOK"
+OUTPUT=$(cat "$ENV_TMP")
+TOTAL=$((TOTAL + 1))
+HAS_EXISTING=$(echo "$OUTPUT" | grep -c 'EXISTING_VAR=hello' || true)
+HAS_HEADLESS=$(echo "$OUTPUT" | grep -c 'FOUNDRY_UI_HEADLESS_MODE=true' || true)
+if [ "$HAS_EXISTING" -ge 1 ] && [ "$HAS_HEADLESS" -ge 1 ]; then
+  PASS=$((PASS + 1))
+  printf "${GREEN}  PASS${RESET} 9.3  appends without overwriting existing content\n"
+else
+  FAIL=$((FAIL + 1))
+  printf "${RED}  FAIL${RESET} 9.3  should preserve existing content and append new var\n"
+fi
+rm -f "$ENV_TMP"
 
 # ---------- Cleanup and Summary ----------
 

--- a/test-skill.sh
+++ b/test-skill.sh
@@ -65,6 +65,9 @@ done
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 RESULT_SCHEMA=$(cat "$SCRIPT_DIR/test-result-schema.json")
 
+# Ensure headless mode for all Foundry CLI commands in this script
+export FOUNDRY_UI_HEADLESS_MODE=true
+
 PROMPT="Create a Falcon Foundry app for me that has an Okta API integration with openapi. Share its listusers endpoint with Falcon Fusion SOAR. Then, create a workflow that can be run on-demand to email or print the list of users. Finally, create a UI extension that calls the listusers endpoint and displays the results. Pick a reasonable app name and proceed without asking me any questions.
 
 When done, respond with valid JSON matching this schema:
@@ -574,7 +577,7 @@ check_deploy_status() {
     # Agent reported success — verify with list-deployments
     for attempt in 1 2 3 4 5 6; do
       local deploy_out
-      deploy_out=$(cd "$app_dir" && FOUNDRY_FF_ENHANCED_UI=false foundry apps list-deployments 2>&1)
+      deploy_out=$(cd "$app_dir" && foundry apps list-deployments 2>&1)
       if echo "$deploy_out" | grep -q "Successful"; then
         echo "DEPLOYED_VERIFIED"; return
       elif echo "$deploy_out" | grep -qE "progress|Deploying|Building"; then
@@ -585,7 +588,7 @@ check_deploy_status() {
     done
     # Agent said SUCCESS but can't confirm — trust it
     local deploy_out
-    deploy_out=$(cd "$app_dir" && FOUNDRY_FF_ENHANCED_UI=false foundry apps list-deployments 2>&1)
+    deploy_out=$(cd "$app_dir" && foundry apps list-deployments 2>&1)
     if echo "$deploy_out" | grep -q "DEPLOYMENT ID"; then
       echo "DEPLOYED_EXISTS"; return
     fi
@@ -594,7 +597,7 @@ check_deploy_status() {
 
   # No agent summary or agent reported failure
   local deploy_out
-  deploy_out=$(cd "$app_dir" && FOUNDRY_FF_ENHANCED_UI=false foundry apps list-deployments 2>&1)
+  deploy_out=$(cd "$app_dir" && foundry apps list-deployments 2>&1)
   if echo "$deploy_out" | grep -q "Successful"; then
     echo "DEPLOYED"; return
   elif echo "$deploy_out" | grep -q "DEPLOYMENT ID"; then

--- a/use-cases/custom-soar-actions.md
+++ b/use-cases/custom-soar-actions.md
@@ -78,7 +78,7 @@ cd okta-demo
 foundry api-integrations create --name "Okta" --spec okta-api.json --no-prompt
 
 # Deploy after API integration is added
-FOUNDRY_FF_ENHANCED_UI=false foundry apps deploy \
+foundry apps deploy \
   --change-type Minor --change-log "Okta API integration" --no-prompt
 ```
 

--- a/use-cases/first-app.md
+++ b/use-cases/first-app.md
@@ -23,9 +23,9 @@ User wants to create their first Falcon Foundry app, scaffold a new app from scr
    - Page: `foundry ui pages create --name "X" --from-template React --no-prompt`
    - Then add navigation: `foundry ui navigation add --name "X" --path / --ref pages.xxx`
 4. **Run locally**: `foundry ui run` starts local dev server on port 25678. Enable Development mode in Falcon console via the `</>` icon.
-5. **Deploy**: `FOUNDRY_FF_ENHANCED_UI=false foundry apps deploy --change-type Major --change-log "Initial deployment" --no-prompt`
+5. **Deploy**: `foundry apps deploy --change-type Major --change-log "Initial deployment" --no-prompt`
 6. **Preview**: Toggle Preview mode on in the `</>` Developer tools to verify deployed app before release.
-7. **Release**: `FOUNDRY_FF_ENHANCED_UI=false foundry apps release --change-type Major --deployment-id <id> --notes "Initial release" --no-prompt`
+7. **Release**: `foundry apps release --change-type Major --deployment-id <id> --notes "Initial release" --no-prompt`
 8. **Install**: Go to Foundry > App catalog, find the app, and Install.
 
 ### Path B: Deploy a Pre-Built Template
@@ -53,9 +53,9 @@ foundry ui extensions create --name "My Extension" \
 foundry ui run
 
 # Deploy, release, install
-FOUNDRY_FF_ENHANCED_UI=false foundry apps deploy \
+foundry apps deploy \
   --change-type Major --change-log "Initial deployment" --no-prompt
-FOUNDRY_FF_ENHANCED_UI=false foundry apps release \
+foundry apps release \
   --change-type Major --deployment-id <id> --notes "v1.0" --no-prompt
 ```
 

--- a/verify-apps.sh
+++ b/verify-apps.sh
@@ -36,6 +36,9 @@ FALCON_URL="${FALCON_URL:-https://falcon.us-2.crowdstrike.com}"
 SKIP_RELEASE="${SKIP_RELEASE:-0}"
 SKIP_BROWSER="${SKIP_BROWSER:-0}"
 
+# Ensure headless mode for all Foundry CLI commands in this script
+export FOUNDRY_UI_HEADLESS_MODE=true
+
 # ── Argument parsing ──────────────────────────────────────────
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -104,7 +107,7 @@ for run_dir in "${RUN_DIRS[@]}"; do
   # Extract deployment info
   # Header line: "Deployments for App: name (app_id)"
   # Table row:   "| deployment_id | version | state |"
-  DEPLOY_OUT=$(cd "$APP_DIR" && FOUNDRY_FF_ENHANCED_UI=false foundry apps list-deployments 2>&1) || true
+  DEPLOY_OUT=$(cd "$APP_DIR" && foundry apps list-deployments 2>&1) || true
   APP_ID=$(echo "$DEPLOY_OUT" | grep -oE '\([0-9a-f]{32}\)' | tr -d '()' | head -1 || echo "")
   DEPLOYMENT_ID=$(echo "$DEPLOY_OUT" | grep '^|' | grep -oE '[0-9a-f]{32}' | head -1 || echo "")
   DEPLOY_STATE=$(echo "$DEPLOY_OUT" | grep -oE 'Successful|Failed|In Progress' | head -1 || echo "Unknown")
@@ -155,7 +158,7 @@ for run_dir in "${RUN_DIRS[@]}"; do
     printf "  Release:       ${RED}skipped (no deployment)${RESET}\n"
   else
     printf "  Releasing...   "
-    RELEASE_OUT=$(cd "$APP_DIR" && FOUNDRY_FF_ENHANCED_UI=false foundry apps release --change-type Patch --deployment-id "$DEPLOYMENT_ID" --notes "Automated release from verify-apps.sh" 2>&1) || true
+    RELEASE_OUT=$(cd "$APP_DIR" && foundry apps release --change-type Patch --deployment-id "$DEPLOYMENT_ID" --notes "Automated release from verify-apps.sh" 2>&1) || true
     if echo "$RELEASE_OUT" | grep -qi "success\|release.*in progress\|released\|complete\|already.*released"; then
       RELEASED=true
       printf "${GREEN}done${RESET}\n"


### PR DESCRIPTION
Per Josh Marlow (Foundry CLI team), FOUNDRY_FF_ENHANCED_UI is a temporary feature flag that will be removed. `FOUNDRY_UI_HEADLESS_MODE=true` is the correct long-term env var for disabling TUI features in headless/CI environments.

Added a SessionStart hook (`hooks/set-foundry-env.sh`) that auto-injects `FOUNDRY_UI_HEADLESS_MODE=true` via `CLAUDE_ENV_FILE` at session start. Users no longer need to prefix deploy/release/list-deployments commands manually. The guard hook is kept as a fallback.

Updated hook logic, skills docs, use cases, and scripts. Removed all inline `FOUNDRY_UI_HEADLESS_MODE=true` prefixes from command examples.

174 hook tests passing. A/B tested: 5/5 deployed, avg ~5.3M tokens/run.