### PR TITLE
Add CrowdStrike logo, Codex/Copilot CLI sections, and broaden pre-flight check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![CrowdStrike Falcon](/images/cs-logo.png?raw=true)
+
 # Falcon Foundry Skills
 
 ![Version](https://img.shields.io/badge/version-1.0.0-blue)
@@ -12,7 +14,7 @@ AI coding assistant skills for building [CrowdStrike Falcon Foundry](https://www
 - **Foundry CLI**: Install with `brew tap crowdstrike/foundry-cli && brew install foundry` (macOS/Linux) or [download for Windows](https://assets.foundry.crowdstrike.com/cli/latest/foundry_Windows_x86_64.zip)
 - **CrowdStrike Account**: With Falcon Foundry access
 - **Authentication**: Run `foundry login` to authenticate
-- **AI Coding Assistant**: Claude Code, Cursor, Gemini CLI, Codex, OpenCode, Copilot CLI, or any tool that supports loading reference documentation
+- **AI Coding Assistant**: Claude Code, Codex, Copilot CLI, Cursor, Gemini CLI, or any tool that supports loading reference documentation
 
 ### Claude Code (Tested)
 
@@ -38,6 +40,30 @@ The `--plugin-dir` flag loads the plugin for that session. To make it permanent,
 ```
 
 Changes to skill files take effect on the next Claude Code session — no reinstall needed.
+
+### Codex (Experimental)
+
+Codex discovers skills from `~/.agents/skills/`. Clone and symlink:
+
+```bash
+git clone https://github.com/CrowdStrike/foundry-skills.git
+mkdir -p ~/.agents/skills
+ln -s /path/to/foundry-skills/skills ~/.agents/skills/foundry-skills
+```
+
+Restart Codex to discover the skills. See the [Codex skills docs](https://developers.openai.com/codex/skills) for details.
+
+### Copilot CLI (Experimental)
+
+Copilot CLI shares the `~/.agents/skills/` discovery directory with Codex:
+
+```bash
+git clone https://github.com/CrowdStrike/foundry-skills.git
+mkdir -p ~/.agents/skills
+ln -s /path/to/foundry-skills/skills ~/.agents/skills/foundry-skills
+```
+
+Restart Copilot CLI to discover the skills.
 
 ### Cursor (Experimental)
 
@@ -71,16 +97,6 @@ gemini skills link /path/to/foundry-skills/skills --scope user
 This creates symlinks in `~/.gemini/skills/` so all skills are available in every workspace. Use `--scope workspace` to install into the current project's `.gemini/skills/` instead. Verify with `gemini skills list` or `/skills list` inside a session.
 
 Gemini activates the right skill on demand based on your prompt. No `GEMINI.md` changes needed.
-
-### Codex (Experimental)
-
-Add to your `AGENTS.md` or project instructions:
-
-```markdown
-## Foundry Development
-Reference the Falcon Foundry skills in /path/to/foundry-skills/skills/ for building Foundry apps.
-The primary orchestrator is foundry-development-workflow/SKILL.md.
-```
 
 ### Other Tools
 

--- a/run-ab-test.sh
+++ b/run-ab-test.sh
@@ -173,20 +173,40 @@ if [ "$NO_SKILL" != "1" ]; then
     git -C "$REPO_ROOT" archive "$BASELINE_REF" | tar -x -C "$MAIN_EXTRACT_DIR"
   fi
 
-  if diff -q "$MAIN_EXTRACT_DIR/skills/foundry-workflows-development/SKILL.md" \
-             "$REPO_ROOT/skills/foundry-workflows-development/SKILL.md" >/dev/null 2>&1; then
-    echo "ERROR: Local skills are identical to main branch."
+  PREFLIGHT_DIFF=0
+  for dir in skills hooks use-cases; do
+    if [ -d "$MAIN_EXTRACT_DIR/$dir" ] || [ -d "$REPO_ROOT/$dir" ]; then
+      if ! diff -rq "$MAIN_EXTRACT_DIR/$dir" "$REPO_ROOT/$dir" >/dev/null 2>&1; then
+        PREFLIGHT_DIFF=1
+        break
+      fi
+    fi
+  done
+  # Also check top-level files that affect plugin behavior
+  for f in CLAUDE.md hooks.json; do
+    if [ -f "$MAIN_EXTRACT_DIR/$f" ] || [ -f "$REPO_ROOT/$f" ]; then
+      if ! diff -q "$MAIN_EXTRACT_DIR/$f" "$REPO_ROOT/$f" >/dev/null 2>&1; then
+        PREFLIGHT_DIFF=1
+        break
+      fi
+    fi
+  done
+  if [ "$PREFLIGHT_DIFF" = "0" ]; then
+    echo "ERROR: Local plugin files are identical to $BASELINE_REF."
     echo ""
     echo "  The A/B test compares baseline ref ($BASELINE_REF) skills (RED) vs local skills (GREEN)."
     echo "  If they're the same, the test is meaningless."
     echo ""
+    echo "  Directories checked: skills/, hooks/, use-cases/"
+    echo "  Files checked: CLAUDE.md, hooks.json"
+    echo ""
     echo "  Common causes:"
-    echo "  - Working tree was reset to $BASELINE_REF"
-    echo "    - Branch has no skill changes"
+    echo "    - Working tree was reset to $BASELINE_REF"
+    echo "    - Branch has no skill/hook changes"
     echo ""
     exit 1
   fi
-  echo "Pre-flight: local skills differ from $BASELINE_REF. Good."
+  echo "Pre-flight: local plugin files differ from $BASELINE_REF. Good."
   echo ""
 fi
 


### PR DESCRIPTION
Add the standard CrowdStrike Falcon logo to the top of the README.

Add Codex and Copilot CLI setup sections using the `~/.agents/skills/` symlink discovery mechanism, sourced from the [Codex skills docs](https://developers.openai.com/codex/skills), the [Copilot CLI changelog](https://github.com/github/copilot-cli/blob/main/changelog.md), and the [dr-jskill reference implementation](https://github.com/jdubois/dr-jskill). Reorder all tool sections alphabetically after Claude Code.

Broaden the A/B test pre-flight check to compare all plugin directories (`skills/`, `hooks/`, `use-cases/`) plus `CLAUDE.md` and `hooks.json`, instead of a single canary file (`foundry-workflows-development/SKILL.md`) that missed changes to other files.