### PR TITLE
Set both FOUNDRY_UI_HEADLESS_MODE and FOUNDRY_FF_ENHANCED_UI

### DIFF
--- a/hooks/set-foundry-env.sh
+++ b/hooks/set-foundry-env.sh
@@ -10,6 +10,10 @@ set -euo pipefail
 
 if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
   echo 'export FOUNDRY_UI_HEADLESS_MODE=true' >> "$CLAUDE_ENV_FILE"
+  # FOUNDRY_FF_ENHANCED_UI=false disables the TUI deploy flow that requires a TTY.
+  # FOUNDRY_UI_HEADLESS_MODE only covers spinners, not deploy/release commands.
+  # Remove once FOUNDRY_UI_HEADLESS_MODE covers the full TUI in a future CLI release.
+  echo 'export FOUNDRY_FF_ENHANCED_UI=false' >> "$CLAUDE_ENV_FILE"
 fi
 
 exit 0


### PR DESCRIPTION
FOUNDRY_UI_HEADLESS_MODE=true only disables TUI spinners, not the enhanced UI deploy flow. The deploy command checks FeatureFlags.EnhancedUI (set from FOUNDRY_FF_ENHANCED_UI, default: true), which requires a TTY.

Now sets both env vars in the SessionStart hook:
- FOUNDRY_UI_HEADLESS_MODE=true (spinners)
- FOUNDRY_FF_ENHANCED_UI=false (TUI deploy flow)

The second var can be removed once FOUNDRY_UI_HEADLESS_MODE covers the full TUI in a future CLI release.

**Testing:** Hook tests still pass (171/171). Verified both env vars are exported.