### PR TITLE
Add AGENTS.md and multi-tool AI assistant support

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,2 @@
+See AGENTS.md for project context and contribution conventions.
+For Foundry skill details, start with skills/foundry-development-workflow/SKILL.md.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+See [AGENTS.md](../AGENTS.md) for AI coding assistant instructions for this repository.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,168 @@
+# AI Agent Instructions for foundry-skills
+
+This repository is an AI coding assistant plugin for [CrowdStrike Falcon Foundry](https://www.crowdstrike.com/en-us/platform/next-gen-siem/falcon-foundry/) development. It provides specialized skills that guide AI assistants through building complete Foundry apps, covering UI pages, serverless functions, data collections, automation workflows, and API integrations.
+
+The skills are markdown-based and usable by any AI coding assistant. Claude Code users should also see [CLAUDE.md](./CLAUDE.md) for plugin-specific hook and integration details.
+
+## Prerequisites
+
+- **Foundry CLI**: Install cross-platform:
+  - macOS/Linux: `brew tap crowdstrike/foundry-cli && brew install crowdstrike/foundry-cli/foundry`
+  - Windows: Download https://assets.foundry.crowdstrike.com/cli/latest/foundry_Windows_x86_64.zip, expand it, add the installation directory to PATH
+- **Authentication**: Run `foundry login` to authenticate with CrowdStrike, or use `foundry profile create --no-prompt` for headless environments
+- **Development Environment**: Node.js, Python, or Go depending on your app requirements
+- **CLI Reference**: https://docs.crowdstrike.com/r/v5114866
+
+## Repository Structure
+
+- `skills/` - 9 specialized development skills, each with a `SKILL.md` file
+- `hooks/` - Hook scripts for Claude Code plugin integration
+- `use-cases/` - Real-world implementation patterns extracted from [CrowdStrike Tech Hub](https://www.crowdstrike.com/tech-hub/ng-siem/?cspage=0&lang=English&type=Article) blog posts
+- `scripts/` - Helper scripts (OpenAPI spec adaptation, linting)
+- `.claude-plugin/` - Claude Code plugin manifest and marketplace configuration
+
+## Skills Ecosystem
+
+The `skills/` directory contains specialized skills that provide systematic approaches for Foundry development. These skills enforce best practices, prevent technical debt, and ensure platform-specific patterns are followed correctly.
+
+### Core Principles
+
+**Mandatory Sub-Skill Delegation**: The foundry-development-workflow skill enforces that all capability development must use the appropriate specialized sub-skill. This prevents platform-specific mistakes and ensures consistent quality.
+
+**Capability-Based Architecture**: Each skill maps to specific Foundry platform capabilities:
+
+- **UI capabilities** → foundry-ui-development
+- **Data capabilities** → foundry-collections-development
+- **Logic capabilities** → foundry-functions-development
+- **Automation capabilities** → foundry-workflows-development
+
+**Security-First Design**: Security patterns are integrated throughout all skills, with dedicated foundry-security-patterns for specialized security guidance.
+
+### Primary Workflow Skills
+
+#### Foundry Development Workflow (Primary Orchestrator)
+
+**Always starts here** - coordinates complete app lifecycle and enforces sub-skill delegation.
+
+**Critical Functions**:
+
+- CLI state management (`foundry profile`, authentication, `foundry ui run`)
+- Manifest.yml coordination across all capabilities
+- Sub-skill delegation enforcement (NO direct implementation allowed)
+
+#### Capability-Specific Skills
+
+**Specialized skills for each Foundry capability type:**
+
+- **foundry-ui-development**: Vue/React + Shoelace UI components and extensions
+- **foundry-collections-development**: JSON Schema data modeling and CRUD operations
+- **foundry-functions-development**: Go/Python serverless functions with CrowdStrike SDK
+- **foundry-workflows-development**: YAML automation workflows and Fusion orchestration
+- **foundry-functions-falcon-api**: Calling Falcon APIs from within Functions (OAuth, SDKs)
+- **foundry-api-integrations**: Exposing external APIs via OpenAPI specs
+
+#### Support Skills
+
+**Cross-cutting concerns and troubleshooting:**
+
+- **foundry-security-patterns**: OAuth scoping, input validation, UI security
+- **foundry-debugging-workflows**: Systematic troubleshooting for CLI, manifest, and API issues
+
+### Use Cases
+
+The `use-cases/` directory contains real-world implementation patterns extracted from [CrowdStrike Tech Hub](https://www.crowdstrike.com/tech-hub/ng-siem/?cspage=0&lang=English&type=Article) blog posts. Each file captures an actionable pattern (not a summary) that AI assistants can apply when users describe similar scenarios. The orchestrator searches use-case frontmatter to match user requests, and sub-skills reference specific use cases for context.
+
+### Skills Usage Patterns
+
+#### Starting New Foundry Development
+
+```
+1. foundry-development-workflow coordinates the lifecycle
+2. Specialized sub-skills for each capability (UI, Collections, Functions, Workflows)
+3. foundry-security-patterns for security review
+```
+
+#### Working with Existing Foundry Apps
+
+```
+1. foundry-development-workflow assesses current state
+2. Appropriate sub-skill for the capability being modified
+3. foundry-debugging-workflows if issues arise
+4. foundry-security-patterns for security validation
+```
+
+#### Common Development Scenarios
+
+- **"Add UI extension"** → foundry-ui-development skill
+- **"Create data schema"** → foundry-collections-development skill
+- **"Build API endpoint"** → foundry-functions-development skill
+- **"Automate workflow"** → foundry-workflows-development skill
+- **"Call Falcon API from Function"** → foundry-functions-falcon-api skill
+- **"Expose external API to Foundry"** → foundry-api-integrations skill
+- **"Troubleshoot deployment"** → foundry-debugging-workflows skill
+
+## Essential Foundry CLI Commands
+
+> **⚠️ CRITICAL: Always use `--no-prompt` with creation commands**
+>
+> AI coding assistants operate in non-interactive environments. Commands that prompt for user input will fail with `Error: EOF`. **ALWAYS** include `--no-prompt` on any command that supports it.
+
+> **🚫 NEVER CREATE APP DIRECTORIES OR FILES MANUALLY**
+>
+> **ABSOLUTELY FORBIDDEN:** Using `mkdir`, `touch`, or manually creating app-related directories (api-integrations/, workflows/, functions/, collections/, ui/) or files (manifest.yml, etc.). The Foundry CLI generates these with correct structure, IDs, and manifest entries.
+>
+> **If a CLI command fails:**
+>
+> 1. ✅ Fix the command (add `--no-prompt`, check flags, verify auth)
+> 2. ✅ Retry the corrected CLI command
+> 3. ❌ **NEVER** fall back to `mkdir` or manual creation
+>
+> **Manual creation causes:** Invalid manifest.yml, missing generated IDs, broken app structure, hours of debugging
+
+```bash
+# Authentication & Environment Management
+foundry login                              # OAuth-based authentication
+foundry profile list                       # View available profiles (US-1, US-2, EU-1, US-GOV)
+foundry profile active                     # Show current active profile
+foundry profile activate --name <name>     # Switch between environments
+
+# App Development Lifecycle
+foundry apps create --name "X" --no-prompt --no-git  # Create new app
+foundry apps run                           # Start full app locally in dev mode
+foundry apps deploy --change-type Patch --change-log "msg" --no-prompt  # Deploy to cloud
+foundry apps release --change-type Patch --deployment-id <id> --notes "notes"  # Release to app catalog
+foundry ui run                             # Local UI development server
+
+# Scaffolding Commands (ALWAYS use --no-prompt)
+foundry api-integrations create --name "X" --spec path.json --no-prompt   # Create API integration
+foundry ui pages create --name "X" --from-template React --no-prompt       # Create UI page
+foundry ui extensions create --name "X" --from-template React --sockets "socket.name" --no-prompt  # Create UI extension
+foundry ui navigation add --name "X" --path / --ref pages.xxx  # Add navigation
+foundry functions create --name "X" --language python --no-prompt           # Create function
+foundry collections create --name "X" --schema path.json --no-prompt        # Create collection
+foundry workflows create --name "X" --spec path.yaml --no-prompt            # Create workflow
+```
+
+## Quality and Thoroughness
+
+When building Falcon Foundry apps, take your time and do each step thoroughly. Quality is more important than speed. Specifically:
+
+- Do not skip validation steps (deploy early after API integrations and collections to catch spec issues)
+- Do not skip the Vite `noAttr()` fix for UI pages - a blank page wastes more time than the 30 seconds to add it
+- Read each sub-skill's Common Pitfalls section before implementing that capability
+- Verify CLI commands succeed before moving to the next step - do not chain multiple scaffolding commands blindly
+
+## Security Considerations
+
+- **Never commit credentials** - CLI handles authentication
+- **Scoped permissions** - Request minimal required permissions in manifest
+- **Iframe security** - UI runs in sandboxed environment
+- **API rate limiting** - Respect CrowdStrike API limits
+
+## Contribution Conventions
+
+- All `SKILL.md` versions must match the version in `.claude-plugin/plugin.json`
+- Hook scripts in `hooks/` must be executable (`chmod +x`)
+- Run `./test-hooks.sh` before submitting a pull request
+- Run `npx markdownlint-cli2 "**/*.md"` to validate markdown formatting
+- Snapshots and use-case files follow standardized frontmatter formats

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,11 @@ Initial public release of Falcon Foundry Skills — AI coding assistant skills f
 ### Use Cases
 
 12 real-world implementation patterns extracted from [CrowdStrike Tech Hub](https://www.crowdstrike.com/tech-hub/ng-siem/) blog posts covering API pagination, detection enrichment, LogScale ingestion, custom SOAR actions, collections, and more.
+
+### Multi-Tool Support
+
+- **`AGENTS.md`** — Canonical AI agent instruction file with tool-agnostic Foundry development guidance (CLI commands, skills ecosystem, quality guidelines, contribution conventions).
+- **`CLAUDE.md`** — Claude Code-specific plugin additions (hooks, superpowers integration, safety enforcement). References `AGENTS.md` for the full development guide.
+- **`.github/copilot-instructions.md`** — Redirect for GitHub Copilot.
+- **`GEMINI.md`** — Redirect for Gemini CLI.
+- **`.cursorrules`** — Redirect for Cursor.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,98 +1,29 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code when working with the foundry-skills plugin.
+Before responding to any Foundry development request, read [AGENTS.md](./AGENTS.md) for the complete CLI reference, skills ecosystem, and development guide.
 
-## Plugin Overview
+Below are Claude Code-specific additions for this plugin.
 
-This plugin provides specialized Claude Code skills for systematic CrowdStrike Foundry development. Clone and configure:
+## Plugin Hook Behavior
 
-```bash
-git clone https://github.com/CrowdStrike/foundry-skills.git
-```
+This plugin includes four hooks that run automatically:
 
-## Prerequisites
+- **SessionStart**: `set-foundry-env.sh` initializes the Foundry environment
+- **UserPromptSubmit**: `foundry-skill-router.sh` routes user intents to the appropriate skill
+- **PreToolUse (Bash)**: `foundry-cli-guard.sh` validates all Bash commands to ensure Foundry CLI commands include `--no-prompt` and blocks manual directory/file creation for app structure
+- **PreToolUse (Skill)**: `superpowers-foundry-bridge.sh` intercepts `superpowers:brainstorming` and redirects to the Foundry development workflow skill
 
-- **Foundry CLI**: Install cross-platform:
-  - macOS/Linux: `brew tap crowdstrike/foundry-cli && brew install crowdstrike/foundry-cli/foundry`
-  - Windows: Download https://assets.foundry.crowdstrike.com/cli/latest/foundry_Windows_x86_64.zip, expand it, add the installation directory to PATH
-- **Authentication**: Run `foundry login` to authenticate with CrowdStrike, or use `foundry profile create --no-prompt` for headless environments
-- **Development Environment**: Node.js, Python, or Go depending on your app requirements
-- **CLI Reference**: https://docs.crowdstrike.com/r/v5114866
+## Automated Safety Enforcement
 
-## Foundry Development Skills Ecosystem
+The `foundry-cli-guard.sh` hook automatically validates all Bash commands to ensure:
 
-### Overview
-The `skills/` directory contains specialized Claude Code skills that provide systematic approaches for Foundry development. These skills enforce best practices, prevent technical debt, and ensure platform-specific patterns are followed correctly.
+- Foundry CLI commands always include `--no-prompt` flag (prevents `Error: EOF` failures)
+- Manual directory/file creation for app structure is blocked (prevents invalid manifest.yml)
+- Commands are corrected before execution with clear error messages
 
-### Core Principles
+This enforcement runs automatically. You don't need to remember the rules; the hook will catch mistakes before they cause failures.
 
-**Mandatory Sub-Skill Delegation**: The foundry-development-workflow skill enforces that all capability development must use the appropriate specialized sub-skill. This prevents platform-specific mistakes and ensures consistent quality.
-
-**Capability-Based Architecture**: Each skill maps to specific Foundry platform capabilities:
-- **UI capabilities** → foundry-ui-development
-- **Data capabilities** → foundry-collections-development
-- **Logic capabilities** → foundry-functions-development
-- **Automation capabilities** → foundry-workflows-development
-
-**Security-First Design**: Security patterns are integrated throughout all skills, with dedicated foundry-security-patterns for specialized security guidance.
-
-### Use Cases
-
-The `use-cases/` directory contains real-world implementation patterns extracted from [CrowdStrike Tech Hub](https://www.crowdstrike.com/tech-hub/ng-siem/?cspage=0&lang=English&type=Article) blog posts. Each file captures an actionable pattern (not a summary) that Claude can apply when users describe similar scenarios. The orchestrator searches use-case frontmatter to match user requests, and sub-skills reference specific use cases for context.
-
-### Primary Workflow Skills
-
-#### Foundry Development Workflow (Primary Orchestrator)
-**Always starts here** - coordinates complete app lifecycle and enforces sub-skill delegation.
-
-**Critical Functions**:
-- CLI state management (`foundry profile`, authentication, `foundry ui run`)
-- Manifest.yml coordination across all capabilities
-- Sub-skill delegation enforcement (NO direct implementation allowed)
-
-#### Capability-Specific Skills
-**Specialized skills for each Foundry capability type:**
-
-- **foundry-ui-development**: Vue/React + Shoelace UI components and extensions
-- **foundry-collections-development**: JSON Schema data modeling and CRUD operations
-- **foundry-functions-development**: Go/Python serverless functions with CrowdStrike SDK
-- **foundry-workflows-development**: YAML automation workflows and Fusion orchestration
-- **foundry-functions-falcon-api**: Calling Falcon APIs from within Functions (OAuth, SDKs)
-- **foundry-api-integrations**: Exposing external APIs via OpenAPI specs
-
-#### Support Skills
-**Cross-cutting concerns and troubleshooting:**
-
-- **foundry-security-patterns**: OAuth scoping, input validation, UI security
-- **foundry-debugging-workflows**: Systematic troubleshooting for CLI, manifest, and API issues
-
-### Skills Usage Patterns
-
-#### Starting New Foundry Development
-```
-1. foundry-development-workflow coordinates the lifecycle
-2. Specialized sub-skills for each capability (UI, Collections, Functions, Workflows)
-3. foundry-security-patterns for security review
-```
-
-#### Working with Existing Foundry Apps
-```
-1. foundry-development-workflow assesses current state
-2. Appropriate sub-skill for the capability being modified
-3. foundry-debugging-workflows if issues arise
-4. foundry-security-patterns for security validation
-```
-
-#### Common Development Scenarios
-- **"Add UI extension"** → foundry-ui-development skill
-- **"Create data schema"** → foundry-collections-development skill
-- **"Build API endpoint"** → foundry-functions-development skill
-- **"Automate workflow"** → foundry-workflows-development skill
-- **"Call Falcon API from Function"** → foundry-functions-falcon-api skill
-- **"Expose external API to Foundry"** → foundry-api-integrations skill
-- **"Troubleshoot deployment"** → foundry-debugging-workflows skill
-
-### Skills Integration with Claude Code Workflows
+## Skills Integration with Claude Code Workflows
 
 **Planning Integration**: For structured planning with review checkpoints, install [superpowers](https://github.com/obra/superpowers) (`superpowers:writing-plans`, `superpowers:executing-plans`). Without superpowers, the orchestrator provides basic planning guidance that accounts for Foundry's 47 capability types and manifest dependencies.
 
@@ -102,9 +33,9 @@ The `use-cases/` directory contains real-world implementation patterns extracted
 
 **Handoff Integration**: Preserve Foundry-specific CLI state (profiles, authentication, `foundry ui run` status) when handing off between sessions.
 
-### Counter-Rationalizations
+## Counter-Rationalizations
 
-**The skills enforce discipline to prevent common failures:**
+The skills enforce discipline to prevent common failures:
 
 | Your Excuse | Reality |
 |-------------|---------|
@@ -113,76 +44,10 @@ The `use-cases/` directory contains real-world implementation patterns extracted
 | "I can learn patterns during implementation" | Learning while implementing = building on wrong assumptions |
 | "Sub-skills are overkill for simple cases" | No Foundry capability is simple - platform complexity is hidden |
 
-### Essential Skills Commands
+## Essential Skills Commands
 
 **Accessing Skills**: Skills are automatically invoked by Claude Code when working on Foundry development tasks. You can reference them explicitly using `@skills/skill-name` syntax.
 
 **Skills Documentation**: Each skill includes comprehensive documentation in its `SKILL.md` file with specific patterns, testing approaches, and integration guidance.
 
 **Skills Coordination**: The foundry-development-workflow skill ensures proper coordination between all sub-skills and maintains CLI state consistency throughout development.
-
-**Automated Safety Enforcement**: The plugin includes a PreToolUse hook (`foundry-cli-guard.sh`) that automatically validates all Bash commands to ensure:
-- Foundry CLI commands always include `--no-prompt` flag (prevents `Error: EOF` failures)
-- Manual directory/file creation for app structure is blocked (prevents invalid manifest.yml)
-- Commands are corrected before execution with clear error messages
-
-This enforcement runs automatically - you don't need to remember the rules, the hook will catch mistakes before they cause failures.
-
-## Essential Foundry CLI Commands
-
-> **⚠️ CRITICAL: Always use `--no-prompt` with creation commands**
->
-> Claude Code operates in a non-interactive environment. Commands that prompt for user input will fail with `Error: EOF`. **ALWAYS** include `--no-prompt` on any command that supports it.
-
-> **🚫 NEVER CREATE APP DIRECTORIES OR FILES MANUALLY**
->
-> **ABSOLUTELY FORBIDDEN:** Using `mkdir`, `touch`, or manually creating app-related directories (api-integrations/, workflows/,
-> functions/, collections/, ui/) or files (manifest.yml, etc.). The Foundry CLI generates these with correct structure, IDs,
-> and manifest entries.
->
-> **If a CLI command fails:**
-> 1. ✅ Fix the command (add `--no-prompt`, check flags, verify auth)
-> 2. ✅ Retry the corrected CLI command
-> 3. ❌ **NEVER** fall back to `mkdir` or manual creation
->
-> **Manual creation causes:** Invalid manifest.yml, missing generated IDs, broken app structure, hours of debugging
-
-```bash
-# Authentication & Environment Management
-foundry login                              # OAuth-based authentication
-foundry profile list                       # View available profiles (US-1, US-2, EU-1, US-GOV)
-foundry profile active                     # Show current active profile
-foundry profile activate --name <name>     # Switch between environments
-
-# App Development Lifecycle
-foundry apps create --name "X" --no-prompt --no-git  # Create new app
-foundry apps run                           # Start full app locally in dev mode
-foundry apps deploy --change-type Patch --change-log "msg" --no-prompt  # Deploy to cloud
-foundry apps release --change-type Patch --deployment-id <id> --notes "notes"  # Release to app catalog
-foundry ui run                             # Local UI development server
-
-# Scaffolding Commands (ALWAYS use --no-prompt)
-foundry api-integrations create --name "X" --spec path.json --no-prompt   # Create API integration
-foundry ui pages create --name "X" --from-template React --no-prompt       # Create UI page
-foundry ui extensions create --name "X" --from-template React --sockets "socket.name" --no-prompt  # Create UI extension
-foundry ui navigation add --name "X" --path / --ref pages.xxx  # Add navigation
-foundry functions create --name "X" --language python --no-prompt           # Create function
-foundry collections create --name "X" --schema path.json --no-prompt        # Create collection
-foundry workflows create --name "X" --spec path.yaml --no-prompt            # Create workflow
-```
-
-## Quality and Thoroughness
-
-When building Falcon Foundry apps, take your time and do each step thoroughly. Quality is more important than speed. Specifically:
-
-- Do not skip validation steps (deploy early after API integrations and collections to catch spec issues)
-- Do not skip the Vite `noAttr()` fix for UI pages — a blank page wastes more time than the 30 seconds to add it
-- Read each sub-skill's Common Pitfalls section before implementing that capability
-- Verify CLI commands succeed before moving to the next step — do not chain multiple scaffolding commands blindly
-
-## Security Considerations
-
-- **Never commit credentials** - CLI handles authentication
-- **Scoped permissions** - Request minimal required permissions in manifest
-- **Iframe security** - UI runs in sandboxed environment
-- **API rate limiting** - Respect CrowdStrike API limits

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,13 @@ The aim of this repository is:
 This repository has a [code of conduct](CODE_OF_CONDUCT.md), we will
 remove things that do not respect it.
 
+## AI-Assisted Contributions
+
+AI coding assistants are welcome for developing contributions to this project.
+If your tool needs project context, see [`AGENTS.md`](AGENTS.md) for orientation
+or [`CLAUDE.md`](CLAUDE.md) for Claude Code-specific plugin guidance. The bar for
+pull requests is the same regardless of how code was written.
+
 ---
 
 <p align="center"><img src="/images/cs-logo-footer.png"><br/><img width="300px" src="/images/turbine-panda.png"></p>

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,2 @@
+@./AGENTS.md
+@./skills/foundry-development-workflow/SKILL.md

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![Version](https://img.shields.io/badge/version-1.0.0-blue)
 [![CI](https://github.com/CrowdStrike/foundry-skills/actions/workflows/main.yml/badge.svg)](https://github.com/CrowdStrike/foundry-skills/actions/workflows/main.yml)
 
-AI coding assistant skills for building [CrowdStrike Falcon Foundry](https://www.crowdstrike.com/platform/next-gen-siem/falcon-foundry/) apps. Build Foundry apps from a natural language prompt — API integrations, workflows, UI pages, functions, and collections — all scaffolded with the Foundry CLI and deployed to the Falcon console.
+AI coding assistant skills for building [CrowdStrike Falcon Foundry](https://www.crowdstrike.com/en-us/platform/next-gen-siem/falcon-foundry/) apps. Build Foundry apps from a natural language prompt — API integrations, workflows, UI pages, functions, and collections — all scaffolded with the Foundry CLI and deployed to the Falcon console.
 
 ## Getting Started
 
@@ -18,7 +18,7 @@ AI coding assistant skills for building [CrowdStrike Falcon Foundry](https://www
 
 ### Claude Code (Tested)
 
-Install as a plugin from the [Anthropic Plugin Marketplace](https://docs.anthropic.com/en/docs/claude-code/plugins):
+Install as a plugin from the [Anthropic Plugin Marketplace](https://github.com/anthropics/claude-plugins-official):
 
 ```
 /plugin install CrowdStrike/foundry-skills
@@ -96,11 +96,11 @@ gemini skills link /path/to/foundry-skills/skills --scope user
 
 This creates symlinks in `~/.gemini/skills/` so all skills are available in every workspace. Use `--scope workspace` to install into the current project's `.gemini/skills/` instead. Verify with `gemini skills list` or `/skills list` inside a session.
 
-Gemini activates the right skill on demand based on your prompt. No `GEMINI.md` changes needed.
+Gemini activates the right skill on demand based on your prompt.
 
 ### Other Tools
 
-These skills are plain markdown files. Any AI coding assistant that can read local files can use them. Point it at the `skills/` directory and start with `foundry-development-workflow/SKILL.md` as the entry point.
+These skills are plain markdown files. Any AI coding assistant that can read local files can use them. See `AGENTS.md` for the full development guide, or point your tool at the `skills/` directory and start with `foundry-development-workflow/SKILL.md` as the entry point.
 
 ## Usage
 


### PR DESCRIPTION
Add `AGENTS.md` as the canonical AI agent instruction file, making the Foundry development guidance accessible to any AI coding assistant (Copilot, Cursor, Gemini CLI, Codex) rather than only Claude Code.

- `AGENTS.md` contains all tool-agnostic content: prerequisites, skills ecosystem, CLI commands, quality guidelines, contribution conventions
- `CLAUDE.md` retains Claude Code-specific additions: plugin hooks, CLI guard behavior, superpowers integration, counter-rationalizations
- Redirect files for Copilot (`.github/copilot-instructions.md`), Gemini CLI (`GEMINI.md`), and Cursor (`.cursorrules`)
- `CONTRIBUTING.md` updated with an AI-assisted contributions section