### PR TITLE
Add self-hosted marketplace install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ Install as a plugin from the [Anthropic Plugin Marketplace](https://github.com/a
 /plugin install CrowdStrike/foundry-skills
 ```
 
+Or install from the CrowdStrike marketplace. Register the marketplace first, then install:
+
+```
+/plugin marketplace add CrowdStrike/foundry-skills
+/plugin install foundry@foundry-skills
+```
+
 Or install from a local clone for development:
 
 ```bash


### PR DESCRIPTION
The repo already ships a `marketplace.json` in `.claude-plugin/`, but the README only documented the Anthropic official marketplace and manual `--plugin-dir` install paths. This adds the self-hosted marketplace option so users can install before Anthropic approves the plugin.

Follows the same pattern superpowers uses in their README for their self-hosted marketplace.