### PR TITLE
Reword marketplace install to avoid implying official CrowdStrike marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Install as a plugin from the [Anthropic Plugin Marketplace](https://github.com/a
 /plugin install CrowdStrike/foundry-skills
 ```
 
-Or install from the CrowdStrike marketplace. Register the marketplace first, then install:
+Or register this repo as a plugin marketplace, then install:
 
 ```
 /plugin marketplace add CrowdStrike/foundry-skills


### PR DESCRIPTION
The self-hosted marketplace install section said "install from the CrowdStrike marketplace," which implies an official CrowdStrike plugin marketplace that doesn't exist. This repo just uses Claude Code's self-hosted marketplace feature. Reworded to "register this repo as a plugin marketplace" to be accurate.