### PR TITLE
Fix brew install command to use fully qualified formula name

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ AI coding assistant skills for building [CrowdStrike Falcon Foundry](https://www
 
 ### Prerequisites
 
-- **Foundry CLI**: Install with `brew tap crowdstrike/foundry-cli && brew install foundry` (macOS/Linux) or [download for Windows](https://assets.foundry.crowdstrike.com/cli/latest/foundry_Windows_x86_64.zip)
+- **Foundry CLI**: Install with `brew tap crowdstrike/foundry-cli && brew install crowdstrike/foundry-cli/foundry` (macOS/Linux) or [download for Windows](https://assets.foundry.crowdstrike.com/cli/latest/foundry_Windows_x86_64.zip)
 - **CrowdStrike Account**: With Falcon Foundry access
 - **Authentication**: Run `foundry login` to authenticate
 - **AI Coding Assistant**: Claude Code, Codex, Copilot CLI, Cursor, Gemini CLI, or any tool that supports loading reference documentation

--- a/skills/development-workflow/references/advanced-patterns.md
+++ b/skills/development-workflow/references/advanced-patterns.md
@@ -11,7 +11,7 @@ Before any Foundry work, verify the CLI is installed and authenticated:
 foundry version
 
 # If not installed:
-#   macOS/Linux: brew tap crowdstrike/foundry-cli && brew install foundry
+#   macOS/Linux: brew tap crowdstrike/foundry-cli && brew install crowdstrike/foundry-cli/foundry
 #   Windows: Download https://assets.foundry.crowdstrike.com/cli/latest/foundry_Windows_x86_64.zip
 #            Expand the archive and add the installation directory to PATH
 


### PR DESCRIPTION
Use `brew install crowdstrike/foundry-cli/foundry` instead of the short-form `brew install foundry` to match the official install instructions in [foundry-tutorial-quickstart](https://github.com/CrowdStrike/foundry-tutorial-quickstart). Flagged by ProdSec review.

Fixes README.md and skills/development-workflow/references/advanced-patterns.md. AGENTS.md already had the correct command.