### PR TITLE
Rename plugin namespace to crowdstrike-falcon-foundry

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "plugins": [
     {
-      "name": "falcon-foundry",
+      "name": "crowdstrike-falcon-foundry",
       "source": "./",
       "description": "CrowdStrike Falcon Foundry development skills for building cybersecurity applications on the Falcon platform. Includes UI development, collections, functions, workflows, API integration, security patterns, and debugging workflows.",
       "version": "1.0.0",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "falcon-foundry",
+  "name": "crowdstrike-falcon-foundry",
   "description": "CrowdStrike Falcon Foundry development skills for building cybersecurity applications on the Falcon platform. Includes UI development, collections, functions, workflows, API integration, security patterns, and debugging workflows.",
   "version": "1.0.0",
   "author": {

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,6 +17,7 @@ abstract: >-
 keywords:
   - crowdstrike
   - crowdstrike-foundry
+  - crowdstrike-falcon-foundry
   - falcon-foundry
   - ai-skills
   - claude-code

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Or register this repo as a plugin marketplace, then install:
 
 ```
 /plugin marketplace add CrowdStrike/foundry-skills
-/plugin install falcon-foundry@foundry-skills
+/plugin install crowdstrike-falcon-foundry@foundry-skills
 ```
 
 Or install from a local clone for development:

--- a/hooks/foundry-skill-router.sh
+++ b/hooks/foundry-skill-router.sh
@@ -60,7 +60,7 @@ case "$HOOK_EVENT" in
       jq -n '{
         hookSpecificOutput: {
           hookEventName: "UserPromptSubmit",
-          additionalContext: "FOUNDRY PLUGIN DETECTED: This prompt involves Falcon Foundry development. Do NOT enter plan mode. IMMEDIATELY invoke falcon-foundry:development-workflow using the Skill tool. That skill handles requirements gathering, clarifying questions, CLI scaffolding, and sub-skill delegation."
+          additionalContext: "FOUNDRY PLUGIN DETECTED: This prompt involves Falcon Foundry development. Do NOT enter plan mode. IMMEDIATELY invoke crowdstrike-falcon-foundry:development-workflow using the Skill tool. That skill handles requirements gathering, clarifying questions, CLI scaffolding, and sub-skill delegation."
         }
       }'
       exit 0
@@ -168,7 +168,7 @@ case "$HOOK_EVENT" in
       jq -n '{
         hookSpecificOutput: {
           hookEventName: "PreToolUse",
-          additionalContext: "Foundry plugin reminder: Consider invoking falcon-foundry:development-workflow skill for Foundry development tasks. It handles CLI scaffolding, manifest coordination, and sub-skill delegation."
+          additionalContext: "Foundry plugin reminder: Consider invoking crowdstrike-falcon-foundry:development-workflow skill for Foundry development tasks. It handles CLI scaffolding, manifest coordination, and sub-skill delegation."
         }
       }'
       exit 0

--- a/hooks/superpowers-foundry-bridge.sh
+++ b/hooks/superpowers-foundry-bridge.sh
@@ -24,7 +24,7 @@ case "$SKILL_NAME" in
     jq -n '{
       hookSpecificOutput: {
         hookEventName: "PreToolUse",
-        additionalContext: "STOP. Do NOT proceed with brainstorming. The Foundry plugin is installed and falcon-foundry:development-workflow MUST be used instead. It handles requirements gathering, CLI scaffolding, and manifest coordination for Foundry apps. Cancel this brainstorming skill invocation and invoke falcon-foundry:development-workflow immediately."
+        additionalContext: "STOP. Do NOT proceed with brainstorming. The Foundry plugin is installed and crowdstrike-falcon-foundry:development-workflow MUST be used instead. It handles requirements gathering, CLI scaffolding, and manifest coordination for Foundry apps. Cancel this brainstorming skill invocation and invoke crowdstrike-falcon-foundry:development-workflow immediately."
       }
     }'
     exit 0
@@ -37,7 +37,7 @@ case "$SKILL_NAME" in
   superpowers:executing-plans|executing-plans|\
   superpowers:subagent-driven-development|subagent-driven-development)
     CONTEXT=$(cat <<'FOUNDRY_CONTEXT'
-FOUNDRY PLUGIN INSTALLED: If this task involves Falcon Foundry, invoke falcon-foundry:development-workflow BEFORE this skill. That skill owns Foundry app creation — it uses CLI commands (foundry apps create, foundry api-integrations create, etc.) that generate manifest.yml and wire up capability IDs correctly. Hand-writing manifest.yml or workflow YAML without the CLI causes deploy failures.
+FOUNDRY PLUGIN INSTALLED: If this task involves Falcon Foundry, invoke crowdstrike-falcon-foundry:development-workflow BEFORE this skill. That skill owns Foundry app creation — it uses CLI commands (foundry apps create, foundry api-integrations create, etc.) that generate manifest.yml and wire up capability IDs correctly. Hand-writing manifest.yml or workflow YAML without the CLI causes deploy failures.
 FOUNDRY_CONTEXT
     )
     jq -n \

--- a/run-ab-test.sh
+++ b/run-ab-test.sh
@@ -239,7 +239,7 @@ while IFS= read -r plugin; do
   if [ -n "$plugin" ] && echo "$PLUGIN_LIST" | grep -A3 "$plugin" | grep -q "enabled"; then
     ENABLED_FOUNDRY_PLUGINS+=("$plugin")
   fi
-done < <(echo "$PLUGIN_LIST" | grep -oE '(foundry|falcon-foundry)@[^ ]*' || true)
+done < <(echo "$PLUGIN_LIST" | grep -oE '(foundry|falcon-foundry|crowdstrike-falcon-foundry)@[^ ]*' || true)
 
 if [ ${#ENABLED_FOUNDRY_PLUGINS[@]} -gt 0 ]; then
   echo "Disabling installed Foundry plugins (using --plugin-dir instead):"

--- a/test-hooks.sh
+++ b/test-hooks.sh
@@ -833,7 +833,7 @@ printf "\n${BOLD}Section 4: PreToolUse — Marker File Advisory${RESET}\n\n"
 # 4.1 — Marker exists, tool is Skill → no output, marker deleted
 cleanup
 echo "$$" > "$MARKER"
-JSON=$(jq -n '{hook_event_name: "PreToolUse", tool_name: "Skill", tool_input: {skill: "falcon-foundry:development-workflow"}}')
+JSON=$(jq -n '{hook_event_name: "PreToolUse", tool_name: "Skill", tool_input: {skill: "crowdstrike-falcon-foundry:development-workflow"}}')
 OUTPUT=$(run_hook "$HOOK" "$JSON")
 assert_empty "$OUTPUT" "4.1  Skill tool → no output"
 assert_marker_not_exists "4.1  Skill tool → marker deleted"
@@ -892,9 +892,9 @@ JSON=$(jq -n '{hook_event_name: "PreToolUse", tool_name: "Skill", tool_input: {s
 OUTPUT=$(run_hook "$BRIDGE" "$JSON")
 assert_empty "$OUTPUT" "5.5  test-driven-development → no output"
 
-# 5.6 — falcon-foundry:development-workflow → no output
+# 5.6 — crowdstrike-falcon-foundry:development-workflow → no output
 cleanup
-JSON=$(jq -n '{hook_event_name: "PreToolUse", tool_name: "Skill", tool_input: {skill: "falcon-foundry:development-workflow"}}')
+JSON=$(jq -n '{hook_event_name: "PreToolUse", tool_name: "Skill", tool_input: {skill: "crowdstrike-falcon-foundry:development-workflow"}}')
 OUTPUT=$(run_hook "$BRIDGE" "$JSON")
 assert_empty "$OUTPUT" "5.6  foundry skill → no output"
 

--- a/test-skill.sh
+++ b/test-skill.sh
@@ -96,7 +96,7 @@ if [ "$SKIP_PLUGIN_MANAGE" != "1" ] && [ "$NO_PLUGIN" != "1" ] && [ -n "$PLUGIN_
     if [ -n "$plugin" ] && echo "$PLUGIN_LIST" | grep -A3 "$plugin" | grep -q "enabled"; then
       ENABLED_FOUNDRY_PLUGINS+=("$plugin")
     fi
-  done < <(echo "$PLUGIN_LIST" | grep -oE '(foundry|falcon-foundry)@[^ ]*' || true)
+  done < <(echo "$PLUGIN_LIST" | grep -oE '(foundry|falcon-foundry|crowdstrike-falcon-foundry)@[^ ]*' || true)
 
   if [ ${#ENABLED_FOUNDRY_PLUGINS[@]} -gt 0 ]; then
     echo "Disabling installed Foundry plugins (using --plugin-dir instead):"
@@ -452,7 +452,7 @@ for m in re.finditer(r'\{[^{}]*(?:\{[^{}]*\}[^{}]*)*(?:\[[^\[\]]*(?:\[[^\[\]]*\]
   # Check orchestrator skill usage
   if [ -s "$SKILLS_FILE" ] && grep -qi "development-workflow" "$SKILLS_FILE" 2>/dev/null; then
     echo "  ✅ Used Foundry orchestrator skill"
-  elif grep -qi "falcon-foundry:development-workflow\|development-workflow" "$TEXT_FILE" 2>/dev/null; then
+  elif grep -qi "crowdstrike-falcon-foundry:development-workflow\|development-workflow" "$TEXT_FILE" 2>/dev/null; then
     echo "  ✅ Used Foundry orchestrator skill"
   else
     echo "  ⚠️  May not have used Foundry orchestrator skill"


### PR DESCRIPTION
Anthropic prefers the `crowdstrike-falcon-foundry` namespace for the official marketplace listing since it's more informative.

Updates plugin.json, marketplace.json, skill namespace references in hooks, test scripts, and the install command in README. All 176 hook tests pass.