### PR TITLE
Fix release.sh remote detection for SSH URLs

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -76,7 +76,7 @@ main() {
   while IFS= read -r line; do
     name=$(echo "$line" | awk '{print $1}')
     url=$(echo "$line" | awk '{print $2}')
-    if [[ "$url" == *"/CrowdStrike/foundry-skills"* ]]; then
+    if [[ "$url" == *"CrowdStrike/foundry-skills"* ]]; then
       remote="$name"
       break
     fi


### PR DESCRIPTION
The pattern matched `/CrowdStrike/foundry-skills` which only works for HTTPS remotes. SSH remotes use a colon separator (`git@github.com:CrowdStrike/foundry-skills.git`), so the leading slash caused origin to not be found.

Removes the leading `/` so both URL formats match.