### PR TITLE
Update README install command for official marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,10 @@ AI coding assistant skills for building [CrowdStrike Falcon Foundry](https://www
 
 ### Claude Code (Tested)
 
-Install as a plugin from the [Anthropic Plugin Marketplace](https://github.com/anthropics/claude-plugins-official):
+Install from the [Anthropic Plugin Marketplace](https://github.com/anthropics/claude-plugins-official):
 
 ```
-/plugin install CrowdStrike/foundry-skills
-```
-
-Or register this repo as a plugin marketplace, then install:
-
-```
-/plugin marketplace add CrowdStrike/foundry-skills
-/plugin install crowdstrike-falcon-foundry@foundry-skills
+/plugin install crowdstrike-falcon-foundry
 ```
 
 Or install from a local clone for development:

--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ Install from the [Anthropic Plugin Marketplace](https://github.com/anthropics/cl
 /plugin install crowdstrike-falcon-foundry
 ```
 
+Or install directly from this repo:
+
+```
+/plugin marketplace add CrowdStrike/foundry-skills
+/plugin install crowdstrike-falcon-foundry@foundry-marketplace
+```
+
 Or install from a local clone for development:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Install from the [Anthropic Plugin Marketplace](https://github.com/anthropics/cl
 /plugin install crowdstrike-falcon-foundry
 ```
 
-Or install directly from this repo:
+Or register this repo as a plugin marketplace, then install:
 
 ```
 /plugin marketplace add CrowdStrike/foundry-skills


### PR DESCRIPTION
Now that the plugin is in the Anthropic Plugin Marketplace, simplify the install instructions to:

```
/plugin install crowdstrike-falcon-foundry
```