### PR TITLE
Add e2e-testing skill and agentskills.io metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .idea/
 __pycache__/
+.playwright-mcp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@ The `skills/` directory contains specialized skills that provide systematic appr
 
 - **security-patterns**: OAuth scoping, input validation, UI security
 - **debugging-workflows**: Systematic troubleshooting for CLI, manifest, and API issues
+- **e2e-testing**: End-to-end testing with `@crowdstrike/foundry-playwright`
 
 ### Use Cases
 
@@ -100,6 +101,7 @@ The `use-cases/` directory contains real-world implementation patterns extracted
 - **"Call Falcon API from Function"** → functions-falcon-api skill
 - **"Expose external API to Foundry"** → api-integrations skill
 - **"Troubleshoot deployment"** → debugging-workflows skill
+- **"Add e2e tests"** → e2e-testing skill
 
 ## Essential Foundry CLI Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.1.0] - TBD
+
+### Added
+
+- **e2e-testing skill** — End-to-end testing for Foundry apps using `@crowdstrike/foundry-playwright`. Covers the 4-project pipeline (authenticate → install → test → uninstall), page objects, configuration screens, custom page objects, CI with GitHub Actions, and debugging with Playwright MCP.
+- **NGSIEM query export use case** — Export Falcon Next-Gen SIEM query results to CSV/JSON via Foundry functions with pagination and scheduled workflow patterns.
+- **Foundry-JS SDK reference** — `falcon.api.workflows`, `falcon.logscale`, `falcon.cloudFunction`, and collections CRUD patterns for `@crowdstrike/foundry-js` in `ui-development/references/foundry-js-sdk.md`.
+- **Visual debugging section** in debugging-workflows — Screenshot-based troubleshooting with Playwright MCP and test failure artifacts.
+- **agentskills.io metadata** — All skills now have top-level `tags`, `author`, `license`, and `compatibility` fields per the [agentskills.io](https://agentskills.io) open spec.
+
+### Changed
+
+- **development-workflow** — Expanded e2e testing guidance with credential configuration details, non-SSO user requirement, and app name alignment.
+
 ## [1.0.0] - 2026-04-29
 
 Initial public release of Falcon Foundry Skills — AI coding assistant skills for building CrowdStrike Falcon Foundry apps.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 - **development-workflow** — Expanded e2e testing guidance with credential configuration details, non-SSO user requirement, and app name alignment.
 
+### Removed
+
+- **UI skill: stale E2E Testing section** — Removed placeholder in `ui-development/references/advanced-patterns.md` that used imaginary helpers predating `@crowdstrike/foundry-playwright`. Proper guidance now lives in the dedicated e2e-testing skill.
+
 ## [1.0.0] - 2026-04-29
 
 Initial public release of Falcon Foundry Skills — AI coding assistant skills for building CrowdStrike Falcon Foundry apps.

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ The skills include hooks that ensure the right skills get used:
 | `collections-development` | JSON Schema data modeling and CRUD operations |
 | `security-patterns` | OAuth scoping, input validation, content security |
 | `debugging-workflows` | Systematic troubleshooting for CLI, manifest, and deployment issues |
+| `e2e-testing` | End-to-end testing with `@crowdstrike/foundry-playwright` |
 
 ## Architecture
 
@@ -188,6 +189,7 @@ The `use-cases/` directory contains real-world implementation patterns extracted
 - LogScale data ingestion from functions
 - Lookup table enrichment with 3rd-party data
 - Custom SOAR actions
+- NGSIEM query export to CSV/JSON
 - Publishing certified apps
 - And more (see [use-cases/README.md](use-cases/README.md))
 

--- a/skills/api-integrations/SKILL.md
+++ b/skills/api-integrations/SKILL.md
@@ -3,10 +3,12 @@ name: api-integrations
 description: Expose external APIs to Falcon Foundry via OpenAPI specs. TRIGGER when user asks to "create an API integration", "adapt an OpenAPI spec for Foundry", "expose an API to workflows", "connect to a third-party API", or runs `foundry api-integrations create`. Also trigger when user has an OpenAPI/Swagger spec and wants it working in Falcon Foundry. DO NOT TRIGGER when user wants to call Falcon platform APIs from function code — use functions-falcon-api instead.
 version: 1.0.0
 updated: 2026-04-29
+tags: [foundry, openapi, api, workflows]
+author: CrowdStrike
+license: MIT
+compatibility: Claude Code >=1.0
 metadata:
-  author: CrowdStrike
   category: integration
-  tags: [foundry, openapi, api, workflows]
 ---
 
 # Foundry API Integrations

--- a/skills/api-integrations/references/calling-patterns.md
+++ b/skills/api-integrations/references/calling-patterns.md
@@ -216,6 +216,16 @@ func main() {
 }
 ```
 
+## Extracting Fields from API Responses
+
+Before writing code that reads fields from an API response, verify the field's location in the OpenAPI spec's response schema. Fields are often nested under objects (e.g., `meta.severity` not `severity`). Similarly, query parameter names may differ from response field names (e.g., filtering by `meta.severity` even though the CSV column is just `severity`).
+
+**Checklist:**
+1. Find the endpoint's response schema in the OpenAPI spec
+2. Trace the field path — is it top-level or nested under an object?
+3. For query parameters, check the `parameters` section for the exact name
+4. Match your struct/dict access to the actual nesting (e.g., `ioc.get("meta", {}).get("severity", '')`)
+
 ## Key Points
 
 | Aspect | Detail |

--- a/skills/collections-development/SKILL.md
+++ b/skills/collections-development/SKILL.md
@@ -236,7 +236,7 @@ client = CustomStorage(ext_headers=_app_headers())
 
 # Create or update (PutObject = upsert). Pass body as a dict.
 client.PutObject(collection_name="incidents", object_key="incident-123",
-    body={"id": "incident-123", "title": "Suspicious process", "severity": 7})
+                 body={"id": "incident-123", "title": "Suspicious process", "severity": 7})
 
 # Read — GetObject returns bytes on success, dict on error
 response = client.GetObject(collection_name="incidents", object_key="incident-123")
@@ -248,7 +248,7 @@ client.DeleteObject(collection_name="incidents", object_key="incident-123")
 
 # Search (FQL filter — only indexed fields)
 response = client.SearchObjects(collection_name="incidents",
-    filter="status:'open'+severity:>=5", limit=50)
+                                filter="status:'open'+severity:>=5", limit=50)
 # SearchObjects returns metadata — follow up with GetObject per key for full objects
 for item in response.get("body", {}).get("resources", []):
     obj = client.GetObject(collection_name="incidents", object_key=item["object_key"])

--- a/skills/collections-development/SKILL.md
+++ b/skills/collections-development/SKILL.md
@@ -3,10 +3,12 @@ name: collections-development
 description: Design JSON Schema collections and CRUD patterns for Falcon Foundry apps. TRIGGER when user asks to "create a collection", "define a JSON schema", "store data in Foundry", runs `foundry collections create`, or needs help with indexable fields, FQL queries, or collection access patterns. DO NOT TRIGGER for workflow YAML, function handlers, or UI components — use the appropriate sub-skill.
 version: 1.0.0
 updated: 2026-04-29
+tags: [foundry, collections, json-schema, nosql]
+author: CrowdStrike
+license: MIT
+compatibility: Claude Code >=1.0
 metadata:
-  author: CrowdStrike
   category: data
-  tags: [foundry, collections, json-schema, nosql]
 ---
 
 # Foundry Collections Development

--- a/skills/debugging-workflows/SKILL.md
+++ b/skills/debugging-workflows/SKILL.md
@@ -234,3 +234,4 @@ Before seeking external help:
 - [ ] Reviewed CLI error messages
 - [ ] Attempted recovery procedures
 - [ ] Documented reproduction steps
+

--- a/skills/debugging-workflows/SKILL.md
+++ b/skills/debugging-workflows/SKILL.md
@@ -3,10 +3,12 @@ name: debugging-workflows
 description: Systematic troubleshooting for Falcon Foundry CLI errors, manifest validation failures, deploy failures, and development server issues. TRIGGER when user encounters CLI errors, `foundry ui run` not working, deploy failures, authentication issues, or any unexpected behavior during Foundry app development. Also trigger for headless/CI environment setup failures.
 version: 1.0.0
 updated: 2026-04-29
+tags: [foundry, debugging, cli, deployment]
+author: CrowdStrike
+license: MIT
+compatibility: Claude Code >=1.0
 metadata:
-  author: CrowdStrike
   category: troubleshooting
-  tags: [foundry, debugging, cli, deployment]
 ---
 
 # Foundry Debugging Workflows
@@ -215,3 +217,20 @@ Before seeking external help:
 - [ ] Reviewed CLI error messages
 - [ ] Attempted recovery procedures
 - [ ] Documented reproduction steps
+
+## Visual Debugging with Screenshots
+
+Claude Code can read images directly. When the Falcon console shows something unexpected — a blank page, an error modal, a disabled button — a screenshot is often the fastest way to diagnose the issue.
+
+**Without Playwright MCP (fastest):** Ask the user to take a screenshot of what they're seeing and paste or drag it into the conversation. Claude reads it immediately and can identify error messages, missing elements, wrong page states, or styling issues without any setup.
+
+**With Playwright MCP:** If Playwright MCP is configured (`claude mcp add playwright -- npx @playwright/mcp@latest`), Claude can take screenshots directly via `browser_take_screenshot`. This is useful for interactive debugging sessions. See `e2e-testing/references/debugging-with-mcp.md` for details.
+
+**From test failure artifacts:** When e2e tests fail, Playwright saves screenshots to `test-results/`. Read the `.png` file directly — it shows the exact page state at the moment of failure.
+
+Screenshots are particularly effective for:
+- Blank pages after deploy (missing iframe, broken Vite config)
+- Extension buttons that don't appear or expand
+- Error banners or modals with messages not surfaced by the CLI
+- `foundry ui run` rendering issues (dark mode, missing Shoelace styles)
+- App install dialogs with unexpected form fields

--- a/skills/debugging-workflows/SKILL.md
+++ b/skills/debugging-workflows/SKILL.md
@@ -189,6 +189,23 @@ When a Foundry app fails to install with no useful error message, isolate the pr
 
 > **Example:** Apps failed to install with no detail. API integration tested fine. Editing the workflow in the console revealed "unknown variable" on the Print data action — the CEL variable path was missing the `Custom_` prefix the platform adds to all API integration names. The install error gave no hint; the workflow editor showed it immediately.
 
+## Visual Debugging with Screenshots
+
+Claude Code can read images directly. When the Falcon console shows something unexpected — a blank page, an error modal, a disabled button — a screenshot is often the fastest way to diagnose the issue.
+
+**Without Playwright MCP (fastest):** Ask the user to take a screenshot of what they're seeing and paste or drag it into the conversation. Claude reads it immediately and can identify error messages, missing elements, wrong page states, or styling issues without any setup.
+
+**With Playwright MCP:** If Playwright MCP is configured (`claude mcp add playwright -- npx @playwright/mcp@latest`), Claude can take screenshots directly via `browser_take_screenshot`. This is useful for interactive debugging sessions. See `e2e-testing/references/debugging-with-mcp.md` for details.
+
+**From test failure artifacts:** When e2e tests fail, Playwright saves screenshots to `test-results/`. Read the `.png` file directly — it shows the exact page state at the moment of failure.
+
+Screenshots are particularly effective for:
+- Blank pages after deploy (missing iframe, broken Vite config)
+- Extension buttons that don't appear or expand
+- Error banners or modals with messages not surfaced by the CLI
+- `foundry ui run` rendering issues (dark mode, missing Shoelace styles)
+- App install dialogs with unexpected form fields
+
 ## Recovery Strategies
 
 ### Profile Corruption
@@ -217,20 +234,3 @@ Before seeking external help:
 - [ ] Reviewed CLI error messages
 - [ ] Attempted recovery procedures
 - [ ] Documented reproduction steps
-
-## Visual Debugging with Screenshots
-
-Claude Code can read images directly. When the Falcon console shows something unexpected — a blank page, an error modal, a disabled button — a screenshot is often the fastest way to diagnose the issue.
-
-**Without Playwright MCP (fastest):** Ask the user to take a screenshot of what they're seeing and paste or drag it into the conversation. Claude reads it immediately and can identify error messages, missing elements, wrong page states, or styling issues without any setup.
-
-**With Playwright MCP:** If Playwright MCP is configured (`claude mcp add playwright -- npx @playwright/mcp@latest`), Claude can take screenshots directly via `browser_take_screenshot`. This is useful for interactive debugging sessions. See `e2e-testing/references/debugging-with-mcp.md` for details.
-
-**From test failure artifacts:** When e2e tests fail, Playwright saves screenshots to `test-results/`. Read the `.png` file directly — it shows the exact page state at the moment of failure.
-
-Screenshots are particularly effective for:
-- Blank pages after deploy (missing iframe, broken Vite config)
-- Extension buttons that don't appear or expand
-- Error banners or modals with messages not surfaced by the CLI
-- `foundry ui run` rendering issues (dark mode, missing Shoelace styles)
-- App install dialogs with unexpected form fields

--- a/skills/development-workflow/SKILL.md
+++ b/skills/development-workflow/SKILL.md
@@ -230,7 +230,7 @@ When running e2e tests against a CrowdStrike/foundry-sample-* app on GitHub:
    foundry apps release --deployment-id <id> --change-type Patch --notes "e2e testing" --no-prompt
    ```
 
-4. **Run tests:** `cd e2e && npx playwright test`
+4. **Run tests:** `cd e2e && npm test`
 
 5. **Revert manifest:** `git checkout manifest.yml` (deploy writes IDs into the manifest)
 

--- a/skills/development-workflow/SKILL.md
+++ b/skills/development-workflow/SKILL.md
@@ -3,10 +3,12 @@ name: development-workflow
 description: Orchestrates the complete Falcon Foundry app lifecycle from requirements through deployment. TRIGGER when user asks to "create a Foundry app", "build a Foundry app", "plan a Foundry app", runs any `foundry apps` CLI command, or discusses Foundry app architecture. DO NOT TRIGGER when user is working on a specific capability (UI, function, workflow, collection) within an existing app — use the appropriate sub-skill instead. This skill OWNS the entire Foundry development flow. Do not delegate Foundry app creation to superpowers:brainstorming or superpowers:writing-plans — those skills do not know about the Foundry CLI.
 version: 1.0.0
 updated: 2026-04-29
+tags: [foundry, lifecycle, cli, deployment]
+author: CrowdStrike
+license: MIT
+compatibility: Claude Code >=1.0
 metadata:
-  author: CrowdStrike
   category: orchestration
-  tags: [foundry, lifecycle, cli, deployment]
 ---
 
 # Foundry Development Workflow
@@ -55,6 +57,7 @@ Implement a known pattern (pagination, enrichment, ingestion, etc.)
 
 Debug / troubleshoot      → debugging-workflows
 Security review           → security-patterns
+E2E testing / Playwright  → e2e-testing
 ```
 
 ## App Creation Flow
@@ -212,27 +215,24 @@ When `manifest.yml` already exists, work is primarily editing existing files. Us
 
 ## Testing an Existing App Locally
 
-When running e2e tests against an existing app:
+When running e2e tests against a CrowdStrike/foundry-sample-* app on GitHub:
 
-1. **Update manifest name** if needed (to match `APP_NAME` in `e2e/.env`)
-2. **Deploy and release:**
+1. **Configure credentials** — copy `.env.sample` to `.env` in the `e2e/` directory and fill in valid Falcon credentials (username, password, TOTP secret, base URL) and app name. `APP_NAME` defaults to the repo name. `FALCON_` credentials must be for a non-SSO user because TOTP is used in e2e tests. This file is gitignored and required for local test runs.
+
+2. **Align the app name** — the manifest `name` and the e2e test `APP_NAME` environment variable (in `.env`) must match for local test runs. CI pipelines typically rewrite the manifest name automatically (e.g., `${REPO}-ci-${PIPELINE_ID}`), so this only affects local development. Preferred approach: update the manifest `name` to match the repo name (e.g., `foundry-sample-logscale`) to avoid spaces and simplify artifact lookup. Remember to `git checkout manifest.yml` after deploy to revert ID changes.
+
+3. **Deploy and release:**
    ```bash
-   foundry apps deploy --change-type patch --change-log "e2e testing" --no-prompt
+   foundry apps deploy --change-type Patch --change-log "e2e testing" --no-prompt
    # Poll until successful
    foundry apps list-deployments
    # Release
-   foundry apps release --deployment-id <id> --change-type patch --notes "e2e testing" --no-prompt
+   foundry apps release --deployment-id <id> --change-type Patch --notes "e2e testing" --no-prompt
    ```
-3. **Run tests:** `cd e2e && npx playwright test`
-4. **Revert manifest:** `git checkout manifest.yml` (deploy writes IDs into the manifest)
 
-### App Name Alignment
+4. **Run tests:** `cd e2e && npx playwright test`
 
-The manifest `name` and the e2e test `APP_NAME` environment variable must match for local test runs. CI pipelines typically rewrite the manifest name automatically (e.g., `${REPO}-ci-${PIPELINE_ID}`), so this only affects local development.
-
-Two approaches:
-- **Update manifest to match .env** (preferred): Use the repo name (e.g., `foundry-sample-logscale`) to avoid spaces and simplify artifact lookup. Remember to `git checkout manifest.yml` after deploy to revert ID changes.
-- **Update .env to match manifest**: Works but names with spaces can cause issues in some tooling.
+5. **Revert manifest:** `git checkout manifest.yml` (deploy writes IDs into the manifest)
 
 ## Manifest Coordination
 

--- a/skills/e2e-testing/SKILL.md
+++ b/skills/e2e-testing/SKILL.md
@@ -1,0 +1,456 @@
+---
+name: e2e-testing
+description: End-to-end testing for Falcon Foundry apps using Playwright and @crowdstrike/foundry-playwright. TRIGGER when user asks to "add e2e tests", "add playwright tests", "write end-to-end tests", "test my app", or mentions "e2e", "playwright", or "end-to-end" in the context of testing a Foundry app. DO NOT TRIGGER during normal app creation, UI development, or function development. This skill is opt-in; not all apps need e2e tests.
+version: 1.5.0
+updated: 2026-05-08
+tags: [foundry, e2e, playwright, testing]
+author: CrowdStrike
+license: MIT
+compatibility: Claude Code >=1.0
+metadata:
+  category: testing
+---
+
+# Foundry E2E Testing
+
+End-to-end testing for Falcon Foundry apps using [Playwright](https://playwright.dev/) and the [`@crowdstrike/foundry-playwright`](https://github.com/CrowdStrike/foundry-playwright) library.
+
+The library provides authentication, app install/uninstall, page objects, and configuration so each app only writes its app-specific tests.
+
+## Quick Start
+
+### 1. Create the `e2e/` directory
+
+```
+my-foundry-app/
+├── e2e/
+│   ├── .env                    # Local credentials (git-ignored)
+│   ├── .env.sample             # Template for other developers
+│   ├── .gitignore
+│   ├── package.json
+│   ├── playwright.config.ts
+│   └── tests/
+│       └── foundry.spec.ts
+├── manifest.yml
+└── ...
+```
+
+### 2. `package.json`
+
+Node.js LTS is recommended.
+
+```json
+{
+  "name": "playwright-foundry",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "npx playwright test",
+    "test:ui": "npx playwright test --ui",
+    "test:debug": "npx playwright test --debug",
+    "test:verbose": "DEBUG=true npx playwright test --reporter=list"
+  },
+  "type": "commonjs",
+  "devDependencies": {
+    "@crowdstrike/foundry-playwright": "0.5.0",
+    "@types/node": "25.6.0"
+  }
+}
+```
+
+**Always pin exact versions** — never use `"latest"`, `"^"`, or `"~"`. Check npm for the current version of each package.
+
+The library brings `@playwright/test`, `@dotenvx/dotenvx`, and `otpauth` as transitive dependencies. No need to install them separately.
+
+### 3. `.env`
+
+```sh
+FALCON_USERNAME=your.email@company.com
+FALCON_PASSWORD=your-password
+FALCON_AUTH_SECRET=your-totp-secret
+FALCON_BASE_URL=https://falcon.us-2.crowdstrike.com
+APP_NAME=your-app-name
+```
+
+**Convention for sample apps:** Set `APP_NAME` to match the manifest `name` field, which should match the repo name (e.g., `foundry-sample-functions-python`). This avoids spaces in names and simplifies CI. This is a convention, not a hard requirement.
+
+### 4. `playwright.config.ts`
+
+```typescript
+import { defineFoundryConfig } from '@crowdstrike/foundry-playwright';
+
+export default defineFoundryConfig();
+```
+
+This gives you the standard 4-project pipeline automatically:
+1. **setup**: authenticate and save session state
+2. **app-install**: install the app via App Catalog
+3. **chromium**: run your tests
+4. **app-uninstall**: clean up after tests
+
+### 5. `.gitignore`
+
+```
+node_modules/
+playwright/.auth/
+playwright-report/
+test-results/
+.env
+```
+
+### 6. Install and run
+
+```bash
+cd e2e
+npm install
+npx playwright install chromium --with-deps
+npm test
+```
+
+## Writing Tests
+
+### Available page objects
+
+The library provides these page objects:
+
+| Class | Purpose |
+|-------|---------|
+| `WorkflowsPage` | Search, open, execute, and verify Falcon Fusion SOAR workflows |
+| `DetectionExtensionPage` | Navigate to Endpoint Detections, expand extensions, return iframe FrameLocator |
+| `HostManagementPage` | Navigate to host management, retrieve host IDs |
+| `AppCatalogPage` | Install, uninstall, and navigate to apps |
+| `AppBuilderPage` | Disable workflow provisioning before install |
+| `AppManagerPage` | Find and navigate to apps in App Manager |
+| `FoundryHomePage` | Navigate to Falcon Foundry home |
+
+### Fixtures pattern
+
+Create `src/fixtures.ts` to wire up page objects as Playwright fixtures. **Only import what your tests actually use** — don't define unused fixtures:
+
+```typescript
+import { test as baseTest } from '@playwright/test';
+import { DetectionExtensionPage, WorkflowsPage } from '@crowdstrike/foundry-playwright';
+
+type FoundryFixtures = {
+  detectionExtensionPage: DetectionExtensionPage;
+  workflowsPage: WorkflowsPage;
+};
+
+export const test = baseTest.extend<FoundryFixtures>({
+  detectionExtensionPage: async ({ page }, use) => { await use(new DetectionExtensionPage(page)); },
+  workflowsPage: async ({ page }, use) => { await use(new WorkflowsPage(page)); },
+});
+
+export { expect } from '@playwright/test';
+```
+
+Playwright fixtures are lazy (only instantiated when a test requests them), so unused fixtures don't hurt performance — but they add confusion and dead code. Add fixtures as you add tests that need them.
+
+### Example test: workflows
+
+```typescript
+import { test } from '../src/fixtures';
+
+test.describe.configure({ mode: 'serial' });
+
+test('should execute workflow', async ({ workflowsPage }) => {
+  test.setTimeout(180000);
+  await workflowsPage.navigateToWorkflows();
+  await workflowsPage.executeAndVerifyWorkflow('My Workflow Name');
+  await workflowsPage.verifyWorkflowExecutionCompleted();
+});
+
+test('should execute workflow with input', async ({ workflowsPage, hostManagementPage }) => {
+  test.setTimeout(180000);
+  const hostId = await hostManagementPage.getFirstHostId();
+  if (!hostId) { test.skip(true, 'No hosts available'); return; }
+
+  await workflowsPage.navigateToWorkflows();
+  await workflowsPage.executeAndVerifyWorkflow('Host Details Workflow', {
+    inputs: { 'Host ID': hostId },
+  });
+  await workflowsPage.verifyWorkflowExecutionCompleted();
+});
+```
+
+`executeAndVerifyWorkflow()` handles search, execution trigger, and initial verification. `verifyWorkflowExecutionCompleted()` opens the execution detail view in a new tab and polls until the status leaves "In Progress" — it fails the test if the execution reports "Failed" and times out after 120s by default. For render-only checks (e.g., ServiceNow workflows without credentials), use `verifyWorkflowRenders()`.
+
+### Example test: UI extensions
+
+```typescript
+import { test, expect } from '../src/fixtures';
+
+test('should render extension', async ({ detectionExtensionPage }) => {
+  const frame = await detectionExtensionPage.openExtension('hello');
+  await expect(frame.getByText(/My App Title/i)).toBeVisible({ timeout: 10000 });
+});
+```
+
+`openExtension()` navigates to Endpoint Detections, opens the first detection, scrolls to the named extension button, expands it, and returns the iframe FrameLocator.
+
+## Apps with Configuration Screens
+
+If your app has API integration settings during install (e.g., ServiceNow credentials), the default install will fail because the Install button stays disabled until fields are filled.
+
+### 1. Add integration credentials to `.env` and `.env.sample`
+
+```sh
+# .env.sample — commit this as a template
+SERVICENOW_INSTANCE_URL=https://dev123456.service-now.com
+SERVICENOW_USERNAME=your-servicenow-username
+SERVICENOW_PASSWORD=your-servicenow-password
+
+# .env — local values, git-ignored
+SERVICENOW_INSTANCE_URL=https://dev99999.service-now.com
+SERVICENOW_USERNAME=admin
+SERVICENOW_PASSWORD=s3cret
+```
+
+### 2. Create a custom `tests/app-install.setup.ts`
+
+```typescript
+import { test as setup } from '@playwright/test';
+import { AppCatalogPage, config } from '@crowdstrike/foundry-playwright';
+
+setup('install app', async ({ page }) => {
+  const catalog = new AppCatalogPage(page);
+
+  const instanceUrl = process.env.SERVICENOW_INSTANCE_URL;
+  const username = process.env.SERVICENOW_USERNAME;
+  const password = process.env.SERVICENOW_PASSWORD;
+  if (!instanceUrl || !username || !password) {
+    throw new Error('Missing required ServiceNow env vars: SERVICENOW_INSTANCE_URL, SERVICENOW_USERNAME, SERVICENOW_PASSWORD');
+  }
+
+  await catalog.installApp(config.appName, {
+    configureSettings: async (page) => {
+      await page.getByRole('textbox', { name: 'Name', exact: true }).fill('ServiceNow Integration');
+      await page.getByRole('textbox', { name: 'Instance' }).fill(instanceUrl);
+      await page.getByRole('textbox', { name: 'Username' }).fill(username);
+      await page.getByRole('textbox', { name: 'Password' }).fill(password);
+    },
+  });
+});
+```
+
+The library loads `.env` automatically (via `@dotenvx/dotenvx`) so `process.env` values are available without extra setup. In CI, set these as GitHub Actions secrets instead.
+
+### 3. Point the config at the custom install
+
+```typescript
+export default defineFoundryConfig({
+  appInstallDir: './tests',
+});
+```
+
+**How to discover field names:** Use Playwright MCP to take a snapshot of the install page and inspect the form fields. See [debugging-with-mcp.md](references/debugging-with-mcp.md).
+
+### Disabling Workflow Provisioning
+
+Apps with workflows that require valid API credentials will fail during install if you provide fake credentials for the configuration screen. Some workflows are also long-running (e.g., Anomali ThreatStream ingestion) and shouldn't be provisioned during testing because they'll start automatically. Use `AppBuilderPage.disableWorkflowProvisioning()` before install to skip provisioning:
+
+```typescript
+import { test as setup } from '@playwright/test';
+import { AppBuilderPage, AppCatalogPage, config } from '@crowdstrike/foundry-playwright';
+
+setup('install app', async ({ page }) => {
+  setup.setTimeout(300000);
+  const appBuilder = new AppBuilderPage(page);
+  await appBuilder.disableWorkflowProvisioning(config.appName);
+
+  const catalog = new AppCatalogPage(page);
+  await catalog.installApp(config.appName);
+});
+```
+
+This navigates to the App Builder, finds the app, toggles off workflow provisioning for each workflow, and saves. Call it before `installApp()` in your custom `app-install.setup.ts`.
+
+### Multi-Screen Configuration Wizards
+
+Some apps have settings spread across multiple screens (e.g., Workday with 4 screens, SailPoint with 3). Navigate between screens using the "Next setting" button:
+
+```typescript
+import { test as setup } from '@playwright/test';
+import { AppBuilderPage, AppCatalogPage, config } from '@crowdstrike/foundry-playwright';
+
+setup('install app', async ({ page }) => {
+  setup.setTimeout(300000);
+  const appBuilder = new AppBuilderPage(page);
+  await appBuilder.disableWorkflowProvisioning(config.appName);
+
+  const catalog = new AppCatalogPage(page);
+
+  await catalog.installApp(config.appName, {
+    configureSettings: async (page) => {
+      const nextButton = page.getByRole('button', { name: 'Next setting' });
+
+      // Screen 1: First API integration settings
+      await page.getByRole('textbox', { name: 'Name' }).fill('My Integration');
+      await page.getByRole('textbox', { name: 'Host' }).fill('https://api.example.com');
+      await nextButton.click();
+      await page.waitForLoadState('networkidle').catch(() => {});
+
+      // Screen 2: Authentication settings
+      await page.getByRole('textbox', { name: 'Client ID' }).fill(process.env.CLIENT_ID!);
+      await page.getByRole('textbox', { name: 'Client Secret' }).fill(process.env.CLIENT_SECRET!);
+      await nextButton.click();
+      await page.waitForLoadState('networkidle').catch(() => {});
+
+      // Screen 3: Additional settings (last screen — "Install app" button is visible here)
+      await page.getByRole('textbox', { name: 'Tenant ID' }).fill(process.env.TENANT_ID!);
+    },
+  });
+});
+```
+
+The `waitForLoadState('networkidle').catch(() => {})` after each "Next setting" click gives the next screen time to load. The `.catch(() => {})` prevents failures if the page is already idle.
+
+## Custom Page Objects
+
+For app-specific UI that the library doesn't cover, extend `BasePage`:
+
+```typescript
+import { Page, expect } from '@playwright/test';
+import { BasePage, AppCatalogPage, config } from '@crowdstrike/foundry-playwright';
+
+export class MyAppPage extends BasePage {
+  constructor(page: Page) {
+    super(page, 'MyAppPage'); // display name for logging only
+  }
+
+  protected getPagePath(): string {
+    throw new Error('Direct path navigation not supported. Use navigateToInstalledApp() instead.');
+  }
+
+  protected async verifyPageLoaded(): Promise<void> {
+    await this.page.locator('h1').filter({ hasText: /My App/i }).waitFor();
+  }
+
+  async navigateToInstalledApp(): Promise<void> {
+    return this.withTiming(async () => {
+      const catalog = new AppCatalogPage(this.page);
+      await catalog.navigateToInstalledApp(config.appName);
+      await this.verifyPageLoaded();
+    }, 'Navigate to installed app');
+  }
+
+  async verifyAppContent(): Promise<void> {
+    return this.withTiming(async () => {
+      const iframe = this.page.frameLocator('iframe[name="portal"]');
+      const heading = iframe.getByRole('heading', { name: /My App/i });
+      await expect(heading).toBeVisible({ timeout: 10000 });
+    }, 'Verify app content');
+  }
+}
+```
+
+Foundry app page URLs contain deployment-specific IDs that change on every deploy, so never hardcode paths. Use `AppCatalogPage.navigateToInstalledApp()` to navigate via the App Catalog menu instead.
+
+`BasePage` gives you `smartClick()`, `withTiming()`, `navigateToPath()`, `elementExists()`, a `logger`, and a `waiter` (SmartWaiter instance).
+
+Add the custom page to your fixtures alongside library page objects.
+
+## Debugging with Playwright MCP
+
+Playwright MCP is invaluable for writing and debugging e2e tests. See [references/debugging-with-mcp.md](references/debugging-with-mcp.md) for detailed patterns.
+
+**Key principle:** When using Playwright MCP interactively, authentication is manual. Navigate to the Falcon login page, then tell the user: *"Please log in to Falcon in the browser, then let me know when you're ready."* Do not attempt automated TOTP login through MCP.
+
+## CI with GitHub Actions
+
+The sample apps use a shared `e2e.yml` workflow pattern. Rather than duplicating it here (where it would go stale), reference the canonical implementation:
+
+**Reference:** [`foundry-sample-functions-python/.github/workflows/e2e.yml`](https://github.com/CrowdStrike/foundry-sample-functions-python/blob/main/.github/workflows/e2e.yml)
+
+### Key CI concepts
+
+1. **Concurrency serialization**: Only one e2e run per repo at a time (prevents deployment collisions)
+2. **Unique app names**: CI generates a unique name from repo + actor + timestamp to avoid conflicts
+3. **Manifest ID stripping**: `yq -i 'del(.. | select(has("id")).id) | del(.. | select(has("app_id")).app_id)' manifest.yml`
+4. **Deploy → wait → release → test → cleanup**: The workflow deploys, polls for success, releases, runs tests, then always deletes the app
+5. **App cleanup**: `foundry apps delete -f` runs in an `always()` step so apps are cleaned up even on failure
+
+### Required GitHub secrets
+
+| Secret | Purpose |
+|--------|---------|
+| `FOUNDRY_API_CLIENT_ID` | Foundry CLI authentication |
+| `FOUNDRY_API_CLIENT_SECRET` | Foundry CLI authentication |
+| `FOUNDRY_CID` | CrowdStrike Customer ID |
+| `FOUNDRY_CLOUD_REGION` | Cloud region (us-1, us-2, eu-1) |
+| `FALCON_USERNAME` | Falcon console login for Playwright |
+| `FALCON_PASSWORD` | Falcon console password |
+| `FALCON_AUTH_SECRET` | TOTP secret for 2FA |
+
+### CI-specific behavior
+
+The library detects `CI=true` and adjusts:
+- Higher timeouts (60s default vs 45s local)
+- Retries enabled (2 retries vs 0 local)
+- `.env` loading skipped (credentials come from environment)
+
+## `defineFoundryConfig()` Options
+
+| Option | Type | Default |
+|--------|------|---------|
+| `testDir` | `string` | `'./tests'` |
+| `appInstallDir` | `string` | Library built-in (override for apps with config screens) |
+| `timeout` | `number` | 60s (CI) / 45s (local) |
+| `retries` | `number` | 2 (CI) / 0 (local) |
+| `reporter` | `string` | `'list'` |
+| `use` | `object` | Merged with defaults (`testIdAttribute: 'data-test-selector'`) |
+| `projects` | `array` | Replaces the default 4-project pipeline if provided |
+
+### Sidebar navigation flakiness
+
+The Falcon sidebar menu re-renders during navigation, which can detach DOM elements mid-click and cause intermittent timeouts. This affects any test that navigates through the sidebar (detections, workflows, host management, etc.). The library's navigation methods include retry logic for this, but with `retries: 0` locally, a single re-render failure will fail the test.
+
+For apps that navigate through the sidebar, set `retries: 2` to handle this reliably:
+
+```typescript
+export default defineFoundryConfig({ retries: 2 });
+```
+
+## Common Pitfalls
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| "Could not find app in catalog" | `APP_NAME` doesn't match the manifest `name` | Ensure `.env` APP_NAME matches `manifest.yml` name field |
+| Install button stays disabled | App has config screens (API integrations) | Create custom `app-install.setup.ts` with `configureSettings()` |
+| "collection existed previously but was deleted" | Stale IDs in manifest from a previous deployment | Strip all IDs: `yq -i 'del(.. \| select(has("id")).id) \| del(.. \| select(has("app_id")).app_id)' manifest.yml` |
+| Tests fail on first run after deploy | Release not propagated yet | Wait 15-30s after release before running tests; CI workflow includes a sleep |
+| Tests pass locally but fail in CI | Different timeout/retry settings | Check `CI=true` is set; library auto-adjusts timeouts |
+| Login fails with account lockout | Running `npm test` in multiple apps simultaneously | Run tests for one app at a time. Concurrent login attempts against the same Falcon account trigger rate-limiting and temporarily lock the account. |
+
+## Reference Implementations
+
+All [CrowdStrike/foundry-sample-*](https://github.com/CrowdStrike?q=foundry-sample) apps have e2e tests using this library:
+
+| App | Highlights |
+|-----|------------|
+| [foundry-sample-functions-python](https://github.com/CrowdStrike/foundry-sample-functions-python/tree/main/e2e) | `configureSettings()`, workflows, extension, host details |
+| [foundry-sample-mitre](https://github.com/CrowdStrike/foundry-sample-mitre/tree/main/e2e) | Custom page objects (`MitreChartPage`), parallel tests |
+| [foundry-sample-anomali-threatstream](https://github.com/CrowdStrike/foundry-sample-anomali-threatstream/tree/main/e2e) | API integration config |
+| [foundry-sample-category-blocking](https://github.com/CrowdStrike/foundry-sample-category-blocking/tree/main/e2e) | UI page testing |
+| [foundry-sample-charlotte-toolkit](https://github.com/CrowdStrike/foundry-sample-charlotte-toolkit/tree/main/e2e) | Charlotte AI toolkit |
+| [foundry-sample-collections-toolkit](https://github.com/CrowdStrike/foundry-sample-collections-toolkit/tree/main/e2e) | Collection CRUD |
+| [foundry-sample-detection-translation](https://github.com/CrowdStrike/foundry-sample-detection-translation/tree/main/e2e) | Detection extension |
+| [foundry-sample-foundryjs-demo](https://github.com/CrowdStrike/foundry-sample-foundryjs-demo/tree/main/e2e) | Foundry-JS SDK demo |
+| [foundry-sample-idp-notifications](https://github.com/CrowdStrike/foundry-sample-idp-notifications/tree/main/e2e) | IDP notifications |
+| [foundry-sample-insider-risk-sailpoint](https://github.com/CrowdStrike/foundry-sample-insider-risk-sailpoint/tree/main/e2e) | SailPoint integration |
+| [foundry-sample-insider-risk-workday](https://github.com/CrowdStrike/foundry-sample-insider-risk-workday/tree/main/e2e) | Workday integration |
+| [foundry-sample-logscale](https://github.com/CrowdStrike/foundry-sample-logscale/tree/main/e2e) | LogScale data ingestion |
+| [foundry-sample-ngsiem-importer](https://github.com/CrowdStrike/foundry-sample-ngsiem-importer/tree/main/e2e) | Next-Gen SIEM importer |
+| [foundry-sample-openrouter-toolkit](https://github.com/CrowdStrike/foundry-sample-openrouter-toolkit/tree/main/e2e) | OpenRouter AI toolkit |
+| [foundry-sample-rapid-response](https://github.com/CrowdStrike/foundry-sample-rapid-response/tree/main/e2e) | Rapid response |
+| [foundry-sample-scalable-rtr](https://github.com/CrowdStrike/foundry-sample-scalable-rtr/tree/main/e2e) | Scalable RTR |
+| [foundry-sample-servicenow-idp](https://github.com/CrowdStrike/foundry-sample-servicenow-idp/tree/main/e2e) | ServiceNow IDP |
+| [foundry-sample-servicenow-itsm](https://github.com/CrowdStrike/foundry-sample-servicenow-itsm/tree/main/e2e) | ServiceNow ITSM |
+| [foundry-sample-threat-intel](https://github.com/CrowdStrike/foundry-sample-threat-intel/tree/main/e2e) | Threat intelligence |
+| [foundry-sample-zscaler-internet-access](https://github.com/CrowdStrike/foundry-sample-zscaler-internet-access/tree/main/e2e) | Zscaler integration |
+
+## Integration with Other Skills
+
+- **development-workflow**: E2E testing is delegated from the orchestrator when users request it
+- **ui-development**: Tests verify UI pages and extensions render correctly in the Falcon console
+- **workflows-development**: Tests verify workflow execution and completion
+- **debugging-workflows**: Use for deploy/release issues that block testing

--- a/skills/e2e-testing/SKILL.md
+++ b/skills/e2e-testing/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: e2e-testing
 description: End-to-end testing for Falcon Foundry apps using Playwright and @crowdstrike/foundry-playwright. TRIGGER when user asks to "add e2e tests", "add playwright tests", "write end-to-end tests", "test my app", or mentions "e2e", "playwright", or "end-to-end" in the context of testing a Foundry app. DO NOT TRIGGER during normal app creation, UI development, or function development. This skill is opt-in; not all apps need e2e tests.
-version: 1.5.0
-updated: 2026-05-08
+version: 1.0.0
+updated: 2026-04-29
 tags: [foundry, e2e, playwright, testing]
 author: CrowdStrike
 license: MIT

--- a/skills/e2e-testing/references/debugging-with-mcp.md
+++ b/skills/e2e-testing/references/debugging-with-mcp.md
@@ -1,0 +1,130 @@
+# Debugging E2E Tests with Playwright MCP
+
+Playwright MCP provides browser automation tools that are invaluable for writing and debugging Foundry e2e tests.
+
+## Setup
+
+Add the Playwright MCP server to Claude Code:
+
+```bash
+claude mcp add playwright -- npx @playwright/mcp@latest
+```
+
+This gives Claude access to browser automation tools (`browser_navigate`, `browser_snapshot`, `browser_click`, etc.) for interactive debugging.
+
+## Interactive Login
+
+When using Playwright MCP to debug tests interactively, authentication is manual. The automated TOTP flow used by `npm test` does not apply in MCP sessions.
+
+**Pattern:**
+
+1. Navigate to the Falcon console login page:
+   ```
+   browser_navigate: https://falcon.us-2.crowdstrike.com
+   ```
+
+2. **Pause and ask the user to log in manually:**
+   > "Please log in to Falcon in the browser, then let me know when you're ready."
+
+3. Once the user confirms, continue with test actions.
+
+This pause-and-wait pattern applies every time you start a new MCP debugging session. Never attempt to fill login forms or generate TOTP codes through MCP.
+
+## Inspecting Page State
+
+### Snapshots (preferred over screenshots)
+
+```
+browser_snapshot
+```
+
+Returns an accessibility tree of the current page. Use this to:
+- Find exact button names, roles, and `aria-expanded` states for extension buttons
+- Discover form field labels for `configureSettings` callbacks
+- Verify element visibility without visual inspection
+- Get `ref` values for clicking elements
+
+### Screenshots
+
+```
+browser_take_screenshot
+```
+
+Use when you need to see visual layout, loading states, or verify styling. Always capture at 2x DPR for retina displays (Playwright MCP's default).
+
+**Screenshots are extremely effective for debugging Falcon console issues.** When something looks wrong — a blank page, a missing extension, an unexpected error banner — take a screenshot and Claude can read it directly. This is often faster than inspecting the DOM because the Falcon console's visual state (loading spinners, error modals, disabled buttons) tells you immediately what's wrong.
+
+**Pattern: Screenshot-driven debugging**
+1. Navigate to the page where the issue occurs
+2. Take a screenshot: `browser_take_screenshot`
+3. Claude reads the image and identifies the problem (error message, missing element, wrong page state)
+4. Fix the test or app code based on what's visible
+5. Repeat until the page looks correct
+
+## Finding Errors
+
+### Console messages
+
+```
+browser_console_messages: { level: "error" }
+```
+
+Check for JavaScript errors that might cause blank pages, failed API calls, or broken extensions.
+
+### Network requests
+
+```
+browser_network_requests: { static: false, requestBody: false, requestHeaders: false }
+```
+
+Look for failed API calls (4xx/5xx status codes) that might explain missing data or broken workflows.
+
+## Debugging Failing Tests
+
+### Read test failure artifacts
+
+When a test fails, Playwright saves artifacts to `test-results/`:
+
+```
+test-results/
+├── test-name/
+│   ├── test-failed-1.png      # Screenshot at failure
+│   ├── video.webm              # Full test video
+│   └── error-context.md        # Error details with call log
+```
+
+Read `error-context.md` first for a quick diagnosis. The call log shows exactly which locator failed and what the page state was.
+
+### Read the screenshot
+
+```
+Read: test-results/<test-dir>/test-failed-1.png
+```
+
+Claude Code can read images directly — this is one of the most powerful debugging tools available. The screenshot shows the exact page state at the moment of failure: error modals, blank iframes, disabled buttons, loading spinners, or unexpected page content. Often a single screenshot is enough to identify the root cause without any further investigation.
+
+### Common debugging scenarios
+
+**Extension button not found:**
+1. Navigate to detection details via MCP
+2. Take a snapshot to see all buttons
+3. Check the exact extension name (case-sensitive by default)
+
+**Install button disabled:**
+1. Navigate to the app install page via MCP
+2. Take a snapshot to see form fields
+3. Note the exact field labels (Name, Instance, Username, Password)
+4. Create a `configureSettings` callback that fills these fields
+
+**Workflow execution fails:**
+1. Navigate to the workflow via MCP
+2. Open the execution modal
+3. Check if input parameters are required
+4. Verify the workflow name matches exactly (including capitalization)
+
+## Tips
+
+- **Snapshots over screenshots:** Snapshots are faster, text-searchable, and give you `ref` values for interacting with elements.
+- **Check `aria-expanded`:** Extension buttons and menu items use `aria-expanded` to indicate state. The library checks this automatically.
+- **Wait for navigation:** After clicking links in the Falcon console, use `browser_wait_for` to confirm page transitions before taking snapshots.
+- **Read existing test-results:** If a test just failed, read the artifacts before launching MCP. The answer is often in the screenshot or error context.

--- a/skills/functions-development/SKILL.md
+++ b/skills/functions-development/SKILL.md
@@ -3,10 +3,12 @@ name: functions-development
 description: Build serverless Go or Python functions for Falcon Foundry apps. TRIGGER when user asks to "create a function", "write a serverless function", "build backend logic", runs `foundry functions create`, or needs help with FDK handler patterns, function testing, or collection integration from functions. DO NOT TRIGGER for calling Falcon platform APIs from functions — use functions-falcon-api instead. DO NOT TRIGGER for workflow YAML or UI components.
 version: 1.0.0
 updated: 2026-04-29
+tags: [foundry, functions, serverless, python, go]
+author: CrowdStrike
+license: MIT
+compatibility: Claude Code >=1.0
 metadata:
-  author: CrowdStrike
   category: backend
-  tags: [foundry, functions, serverless, python, go]
 ---
 
 # Foundry Functions Development

--- a/skills/functions-development/references/python-patterns.md
+++ b/skills/functions-development/references/python-patterns.md
@@ -139,21 +139,17 @@ def create_incident(client: CustomStorage, data: Dict[str, Any]) -> Dict[str, An
         "created_at": datetime.now(timezone.utc).isoformat(),
         "updated_at": datetime.now(timezone.utc).isoformat(),
     }
-    response = client.PutObject(
-        collection_name=COLLECTION_NAME,
-        object_key=incident_id,
-        body=incident,
-    )
+    response = client.PutObject(collection_name=COLLECTION_NAME,
+                                object_key=incident_id,
+                                body=incident)
     if response["status_code"] != 200:
         raise Exception(f"Failed to create incident: {response.get('errors', [])}")
     return incident
 
 def get_incident(client: CustomStorage, incident_id: str) -> Optional[Dict[str, Any]]:
     """Retrieve an incident by key. GetObject returns bytes — decode to dict."""
-    response = client.GetObject(
-        collection_name=COLLECTION_NAME,
-        object_key=incident_id,
-    )
+    response = client.GetObject(collection_name=COLLECTION_NAME,
+                                object_key=incident_id)
     if isinstance(response, dict) and response.get("status_code") == 404:
         return None
     if isinstance(response, dict) and response.get("status_code", 200) != 200:
@@ -162,19 +158,15 @@ def get_incident(client: CustomStorage, incident_id: str) -> Optional[Dict[str, 
 
 def delete_incident(client: CustomStorage, incident_id: str) -> bool:
     """Delete an incident by key."""
-    response = client.DeleteObject(
-        collection_name=COLLECTION_NAME,
-        object_key=incident_id,
-    )
+    response = client.DeleteObject(collection_name=COLLECTION_NAME,
+                                   object_key=incident_id)
     return response["status_code"] == 200
 
 def search_incidents(client: CustomStorage, fql_filter: str = "", limit: int = 50) -> List[Dict[str, Any]]:
     """Search incidents using FQL filter. Only indexed fields are filterable."""
-    response = client.SearchObjects(
-        collection_name=COLLECTION_NAME,
-        filter=fql_filter,
-        limit=limit,
-    )
+    response = client.SearchObjects(collection_name=COLLECTION_NAME,
+                                    filter=fql_filter,
+                                    limit=limit)
     if response["status_code"] != 200:
         raise Exception(f"Search failed: {response.get('errors', [])}")
     # SearchObjects returns metadata — retrieve full objects by key
@@ -235,7 +227,7 @@ if os.environ.get("APP_ID"):
     headers = {"X-CS-APP-ID": os.environ.get("APP_ID")}
 
 response = client.command("PutObject", collection_name="incidents",
-    object_key="id-123", body={"id": "id-123"}, headers=headers)
+                          object_key="id-123", body={"id": "id-123"}, headers=headers)
 ```
 
 The Foundry functions editor cannot auto-detect scopes from Uber class usage — configure scopes manually in the manifest.

--- a/skills/functions-falcon-api/SKILL.md
+++ b/skills/functions-falcon-api/SKILL.md
@@ -129,11 +129,9 @@ def get_detections(request: Request, config, logger) -> Response:
     severity_min = int(request.params.get("severity_min", 3))
     limit = min(int(request.params.get("limit", 50)), 100)
 
-    query_response = falcon.query_detects(
-        filter=f"max_severity_displayname:>'{severity_min}'",
-        limit=limit,
-        sort="last_behavior|desc"
-    )
+    query_response = falcon.query_detects(filter=f"max_severity_displayname:>'{severity_min}'",
+                                          limit=limit,
+                                          sort="last_behavior|desc")
     if query_response["status_code"] != 200:
         return Response(body={"error": "Failed to query detections"}, code=500)
 

--- a/skills/functions-falcon-api/SKILL.md
+++ b/skills/functions-falcon-api/SKILL.md
@@ -3,10 +3,12 @@ name: functions-falcon-api
 description: Call CrowdStrike Falcon platform APIs (detections, alerts, hosts, RTR) from within Foundry function handlers. TRIGGER when user asks to "call Falcon APIs from a function", "use FalconPy in a function", "use gofalcon in a function", or needs to integrate Falcon platform APIs within serverless function code. DO NOT TRIGGER when user wants to expose external third-party APIs to Foundry — use api-integrations instead.
 version: 1.0.0
 updated: 2026-04-29
+tags: [foundry, functions, falcon-api, falconpy, gofalcon]
+author: CrowdStrike
+license: MIT
+compatibility: Claude Code >=1.0
 metadata:
-  author: CrowdStrike
   category: backend
-  tags: [foundry, functions, falcon-api, falconpy, gofalcon]
 ---
 
 # Falcon API Integration in Functions

--- a/skills/security-patterns/SKILL.md
+++ b/skills/security-patterns/SKILL.md
@@ -3,10 +3,12 @@ name: security-patterns
 description: Security patterns for Falcon Foundry apps including OAuth scopes, RBAC, input validation, UI security, and credential management. TRIGGER when user asks to "configure OAuth scopes", "secure a Foundry app", "handle secrets", "add input validation", or needs to review a Foundry app for security concerns (XSS, CSP, credential management). Also trigger during pre-deployment security reviews.
 version: 1.0.0
 updated: 2026-04-29
+tags: [foundry, oauth, rbac, xss, csp]
+author: CrowdStrike
+license: MIT
+compatibility: Claude Code >=1.0
 metadata:
-  author: CrowdStrike
   category: security
-  tags: [foundry, oauth, rbac, xss, csp]
 ---
 
 # Foundry Security Patterns

--- a/skills/ui-development/SKILL.md
+++ b/skills/ui-development/SKILL.md
@@ -3,10 +3,12 @@ name: ui-development
 description: Build UI pages and extensions for Falcon Foundry apps using React or Vue with the Shoelace design system and Foundry-JS SDK. TRIGGER when user asks to "create a UI page", "build a UI extension", "add a Shoelace component", "call an API from the UI", runs `foundry ui pages create` or `foundry ui run`, or needs help with Vite config, FalconJS SDK, or Falcon console theming. DO NOT TRIGGER for backend functions, workflow YAML, or collection schemas.
 version: 1.0.0
 updated: 2026-04-29
+tags: [foundry, ui, react, vue, shoelace]
+author: CrowdStrike
+license: MIT
+compatibility: Claude Code >=1.0
 metadata:
-  author: CrowdStrike
   category: frontend
-  tags: [foundry, ui, react, vue, shoelace]
 ---
 
 # Foundry UI Development

--- a/skills/ui-development/references/advanced-patterns.md
+++ b/skills/ui-development/references/advanced-patterns.md
@@ -186,44 +186,6 @@ class ExtensionMessaging {
 }
 ```
 
-## E2E Testing with Playwright
-
-**Pattern: Testing in Falcon Console Context**
-
-```typescript
-// e2e/alerts-dashboard.spec.ts
-import { test, expect } from '@playwright/test';
-import { loginToFalcon, navigateToApp } from './helpers/falcon-auth';
-
-test.describe('Alerts Dashboard', () => {
-  test.beforeEach(async ({ page }) => {
-    await loginToFalcon(page);
-    await navigateToApp(page, 'my-foundry-app');
-  });
-
-  test('displays alerts from API', async ({ page }) => {
-    // Wait for data to load
-    await expect(page.locator('sl-spinner')).not.toBeVisible({ timeout: 10000 });
-
-    // Verify table is populated
-    const rows = page.locator('tbody tr');
-    await expect(rows).toHaveCount.greaterThan(0);
-  });
-
-  test('filters alerts by severity', async ({ page }) => {
-    await page.selectOption('sl-select[name="severity"]', '8');
-    await page.click('sl-button[type="submit"]');
-
-    // Verify only high severity alerts shown
-    const badges = page.locator('sl-badge');
-    for (const badge of await badges.all()) {
-      const text = await badge.textContent();
-      expect(parseInt(text || '0')).toBeGreaterThanOrEqual(8);
-    }
-  });
-});
-```
-
 ## Extension Builder (No-Code)
 
 The Extension Builder provides a drag-and-drop alternative to CLI-based UI development. Use it for simple extensions that display contextual data without custom logic.

--- a/skills/ui-development/references/foundry-js-sdk.md
+++ b/skills/ui-development/references/foundry-js-sdk.md
@@ -1,0 +1,179 @@
+# foundry-js SDK Operations
+
+SDK patterns for `@crowdstrike/foundry-js` beyond the React context/navigation covered in `react-patterns.md`. Source: [Getting Started with foundry-js](https://www.crowdstrike.com/tech-hub/ng-siem/getting-started-with-foundry-js-using-the-foundry-js-demo-app/).
+
+## Connection (Required First)
+
+```typescript
+import FalconApi from '@crowdstrike/foundry-js';
+
+const falcon = new FalconApi();
+await falcon.connect(); // MUST complete before any SDK calls
+```
+
+`connect()` also auto-applies theme class (`theme-dark` or `theme-light`) to `<html>`.
+
+## Collections CRUD
+
+```typescript
+// Create a reference (reusable)
+const collection = falcon.collection({ collection: 'demo_items' });
+
+// Write
+await collection.write({ key: 'item-1', data: { name: 'Test', value: 42 } });
+
+// Read
+const item = await collection.read({ key: 'item-1' });
+
+// List/Search with FQL
+const results = await collection.search({ filter: "name:'Test'" });
+
+// Delete
+await collection.delete({ key: 'item-1' });
+```
+
+**Gotcha:** Add 50ms delays between sequential reads to avoid rate limiting in rapid operations.
+
+## Workflow Execution (Async Polling)
+
+Workflows are asynchronous — trigger then poll for completion:
+
+```typescript
+async function executeWorkflow(falcon: FalconApi, workflowId: string, input: object) {
+  // Trigger
+  const trigger = await falcon.workflow({ id: workflowId }).execute({ body: input });
+  const executionId = trigger.execution_id;
+
+  // Poll (up to 20 attempts, ~1s intervals)
+  for (let i = 0; i < 20; i++) {
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    const status = await falcon.workflow({ id: workflowId }).status({ executionId });
+
+    if (status.state === 'Completed') return status.result;
+    if (status.state === 'Failed' || status.state === 'Cancelled') {
+      throw new Error(`Workflow ${status.state}: ${status.error || 'unknown'}`);
+    }
+  }
+  throw new Error('Workflow timed out after 20 attempts');
+}
+```
+
+## LogScale Operations
+
+```typescript
+// Write events
+await falcon.logscale.write({
+  data: [{ message: 'User logged in', userId: '123', timestamp: Date.now() }]
+});
+
+// Dynamic query
+const results = await falcon.logscale.query({
+  query: '#event_simpleName=ProcessRollup2 | count()',
+  start: '-1h',
+  end: 'now'
+});
+
+// Execute saved query by ID
+const saved = await falcon.logscale.savedQuery({ id: 'saved-query-id' });
+```
+
+**Scopes:** `humio-auth-proxy:read` for queries, `humio-auth-proxy:write` for writing events.
+
+## Cloud Functions
+
+Call serverless functions deployed with your app:
+
+```typescript
+const response = await falcon.cloudFunction()
+  .path('/my-endpoint')
+  .post({ key: 'value' });
+
+// GET with query params
+const data = await falcon.cloudFunction()
+  .path('/items')
+  .query({ limit: '10', offset: '0' })
+  .get();
+```
+
+Use cloud functions as an escape hatch when you need to call Falcon API endpoints outside the allowlisted `falcon.api` namespaces.
+
+## Events (Inter-Extension Communication)
+
+```typescript
+// Listen for console context changes (e.g., detection selected)
+const handler = (data: any) => { console.log('Context:', data); };
+falcon.events.on('data', handler);
+
+// Broadcast between extensions on the same page
+falcon.events.broadcast({ type: 'refresh', payload: { id: '123' } });
+
+// Always clean up listeners
+falcon.events.off('data', handler);
+```
+
+## Navigation Gotchas
+
+### Use HashRouter
+
+Standard `BrowserRouter` breaks inside the Falcon console iframe. Always use `HashRouter`:
+
+```tsx
+import { HashRouter, Routes, Route } from 'react-router-dom';
+
+function App() {
+  return (
+    <HashRouter>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/settings" element={<Settings />} />
+      </Routes>
+    </HashRouter>
+  );
+}
+```
+
+### External Links Use navigateTo
+
+Links that navigate outside your app use `falcon.navigation.navigateTo()`:
+
+```tsx
+function ExternalLink({ href, children }) {
+  const { falcon } = useFalconApiContext();
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    if (falcon?.navigation?.navigateTo) {
+      falcon.navigation.navigateTo({ path: e.currentTarget.href });
+    } else {
+      window.open(href, '_blank');
+    }
+  };
+
+  return <a href={href} onClick={handleClick}>{children}</a>;
+}
+```
+
+**Note:** `falcon.navigation.onClick(event.nativeEvent)` is deprecated. Use `navigateTo({ path })` instead — it accepts a URL string directly, no native event required.
+
+## Modal Page IDs
+
+When opening modals, you need the **auto-generated 32-character hex ID** from the deployed manifest, not the page key from your source manifest:
+
+```typescript
+// Wrong — this is your source manifest key
+falcon.navigation.openModal({ pageId: 'my-modal-page' });
+
+// Correct — use the hex ID from the exported/deployed manifest
+falcon.navigation.openModal({ pageId: 'a1b2c3d4e5f6...' });
+```
+
+**How to find it:** Export the deployed manifest or check the `app_id`-suffixed page entries after deploy.
+
+## Theme Best Practices
+
+- **Don't set `theme-dark`/`theme-light` on `<body>`** — foundry-js sets it on `<html>`. Putting it on body causes CSS specificity conflicts.
+- Use `@crowdstrike/tailwind-toucan-base` design tokens for automatic theme adaptation:
+  - `var(--critical)` for error states
+  - `var(--link-color)` for links
+  - `var(--surface-md)` for card backgrounds
+- foundry-js handles theme switching automatically when users toggle dark/light mode in the Falcon console.

--- a/skills/workflows-development/SKILL.md
+++ b/skills/workflows-development/SKILL.md
@@ -3,10 +3,12 @@ name: workflows-development
 description: Create and configure Falcon Fusion SOAR workflow YAML for Falcon Foundry apps. TRIGGER when user asks to "create a workflow", "build an automation", "configure Fusion SOAR", "add an on-demand workflow", runs `foundry workflows create`, or needs help with Fusion YAML syntax, triggers, actions, or variable references. DO NOT TRIGGER for UI pages, functions, or collection schemas — use the appropriate sub-skill.
 version: 1.0.0
 updated: 2026-04-29
+tags: [foundry, workflows, fusion-soar, yaml]
+author: CrowdStrike
+license: MIT
+compatibility: Claude Code >=1.0
 metadata:
-  author: CrowdStrike
   category: automation
-  tags: [foundry, workflows, fusion-soar, yaml]
 ---
 
 # Foundry Workflows Development

--- a/use-cases/api-pagination.md
+++ b/use-cases/api-pagination.md
@@ -35,9 +35,7 @@ User needs to fetch paginated data from an external API (threat intel feeds, CMD
 3. **Loop condition** must check BOTH null and "0": `next:!null+next:!'0'`
 4. **Inside loop**: call function with `${WorkflowCustomVariable.next}`, then UpdateVariable.
 
-### Recommended dev approach
-
-Build the function first, test locally, then add workflow orchestration.
+### Recommended dev approach: Build the function first, test locally, then add workflow orchestration.
 
 ## Key Code
 
@@ -119,15 +117,16 @@ def fetch_with_retry(api, params, logger, max_retries=5):
 **State management with collections:**
 ```python
 def save_pagination_state(key, limit, offset):
-    api = APIHarnessV2()
-    api.command("PutObject", body={"limit": limit, "offset": offset},
-        collection_name="pagination_tracker", object_key=key)
+    custom_storage = CustomStorage(ext_headers=_app_headers())
+    custom_storage.PutObject(body={"limit": limit, "offset": offset},
+                             collection_name="pagination_tracker",
+                             object_key=key)
 
 def get_pagination_state(key):
-    api = APIHarnessV2()
+    custom_storage = CustomStorage(ext_headers=_app_headers())
     try:
-        result = api.command("GetObject",
-            collection_name="pagination_tracker", object_key=key)
+        result = custom_storage.GetObject(collection_name="pagination_tracker",
+                                          object_key=key)
         if isinstance(result, bytes):
             data = json.loads(result.decode("utf-8"))
             return data.get("limit", -1), data.get("offset", -1)

--- a/use-cases/api-pagination.md
+++ b/use-cases/api-pagination.md
@@ -35,7 +35,9 @@ User needs to fetch paginated data from an external API (threat intel feeds, CMD
 3. **Loop condition** must check BOTH null and "0": `next:!null+next:!'0'`
 4. **Inside loop**: call function with `${WorkflowCustomVariable.next}`, then UpdateVariable.
 
-### Recommended dev approach: Build the function first, test locally, then add workflow orchestration.
+### Recommended dev approach
+
+Build the function first, test locally, then add workflow orchestration.
 
 ## Key Code
 

--- a/use-cases/collections.md
+++ b/use-cases/collections.md
@@ -31,7 +31,7 @@ User wants to persist structured data (config, checkpoints, event logs, user pre
      --schema schemas/my_data.json --description "Purpose" --no-prompt
    ```
 3. **Validate early** with `foundry apps validate --no-prompt` to check the schema against the platform.
-4. **Access from functions** using `APIHarnessV2` (see Key Code).
+4. **Access from functions** using `CustomStorage` service class (see Key Code).
 5. **Access from UI extensions** using `@crowdstrike/foundry-js`.
 6. **Configure workflow sharing** if the collection needs to be used in workflows.
 
@@ -61,29 +61,30 @@ User wants to persist structured data (config, checkpoints, event logs, user pre
 
 **CRUD from Python functions (FalconPy):**
 ```python
-from falconpy import APIHarnessV2
+from falconpy import CustomStorage
 import json
 
-api = APIHarnessV2()
-headers = {}  # set X-CS-APP-ID for local testing
+custom_storage = CustomStorage(ext_headers=_app_headers())
 
 # Create/Update
-api.command("PutObject", body=data,
-    collection_name="my_data", object_key=unique_id, headers=headers)
+custom_storage.PutObject(body=data,
+                         collection_name="my_data",
+                         object_key=unique_id)
 
 # Search (returns metadata only, not full objects)
-results = api.command("SearchObjects",
-    filter="severity:'high'", collection_name="my_data",
-    limit=50, sort="timestamp_unix.desc", headers=headers)
+results = custom_storage.SearchObjects(filter="severity:'high'",
+                                       collection_name="my_data",
+                                       limit=50,
+                                       sort="timestamp_unix.desc")
 
 # Get full object (returns bytes)
-obj = api.command("GetObject",
-    collection_name="my_data", object_key=key, headers=headers)
+obj = custom_storage.GetObject(collection_name="my_data",
+                               object_key=key)
 data = json.loads(obj.decode("utf-8"))
 
 # Delete
-api.command("DeleteObject",
-    collection_name="my_data", object_key=key, headers=headers)
+custom_storage.DeleteObject(collection_name="my_data",
+                            object_key=key)
 ```
 
 **FQL query patterns:**

--- a/use-cases/ngsiem-query-export.md
+++ b/use-cases/ngsiem-query-export.md
@@ -1,0 +1,163 @@
+---
+name: ngsiem-query-export
+description: Export Next-Gen SIEM query results to CSV using FoundryLogScale in functions or Event Query in workflows
+source: https://www.crowdstrike.com/tech-hub/ng-siem/exporting-falcon-next-gen-siem-query-results-to-csv-with-falcon-foundry/
+skills: [functions-development, workflows-development, collections-development]
+capabilities: [function, workflow, collection, api-integration]
+---
+
+## When to Use
+
+User needs to export Next-Gen SIEM (LogScale) query results — as CSV files, lookup tables for enrichment, collection records, or payloads to external APIs. The critical decision: use a function for programmatic control or a workflow for visual orchestration.
+
+## Pattern
+
+### Decision: Function vs Workflow
+
+| Factor | Use Function | Use Workflow |
+|--------|-------------|--------------|
+| Output format | Custom CSV, JSON, transformed | CSV file or lookup table |
+| Destination | Collections, API integrations, custom | Lookup files, downstream actions |
+| Query complexity | Dynamic queries, multiple repos | Single Event Query action |
+| Processing | Transform/filter before export | Direct pipe to next action |
+
+### Function-Based (FoundryLogScale SDK)
+
+1. **Import FoundryLogScale** from `falconpy` — requires `humio-auth-proxy:read` scope.
+2. **Choose sync or async** based on expected result size.
+3. **Convert to CSV** using Python's `csv.DictWriter` with `extrasaction='ignore'`.
+4. **Clean up `/tmp` files** in a `finally` block — containers reuse `/tmp` across invocations.
+5. **Send results** to lookup file, collection, or API integration.
+
+### Workflow-Based (Event Query Action)
+
+1. **Add Event Query action** with your LogScale query.
+2. **Set "Output files only: false"** to preserve JSON results for downstream actions.
+3. **Wire `file_csv` output** to Create Lookup File via `${query_action.file_csv}`.
+4. **Or wire JSON results** to collection writes or API integration calls.
+
+## Key Code
+
+**Synchronous LogScale query (small results):**
+```python
+from falconpy import FoundryLogScale
+
+def query_logscale_sync(query_string, repo="search-all", start="-24h", end="now"):
+    logscale = FoundryLogScale()
+    response = logscale.execute_dynamic(app_id="foundry-app",
+                                        repositories=[repo],
+                                        search_query=query_string,
+                                        search_query_start=start,
+                                        search_query_end=end,
+                                        mode="sync")
+    return response["body"]["results"]
+```
+
+**Asynchronous LogScale query (large results):**
+```python
+import time
+
+def query_logscale_async(query_string, repo="search-all"):
+    logscale = FoundryLogScale()
+
+    # Start async job
+    response = logscale.execute_dynamic(app_id="foundry-app",
+                                        repositories=[repo],
+                                        search_query=query_string,
+                                        search_query_start="-7d",
+                                        search_query_end="now",
+                                        mode="async")
+    job_id = response["body"]["job_id"]
+
+    # Poll until complete
+    while True:
+        status = logscale.get_search_status(job_id=job_id)
+        if status["body"].get("done"):
+            break
+        time.sleep(2)
+
+    # Fetch results
+    results = logscale.get_search_results(job_id=job_id)
+    return results["body"]["events"]
+```
+
+**CSV conversion with field filtering:**
+```python
+import csv, io
+
+def results_to_csv(results, fields=None):
+    if not results:
+        return ""
+
+    if fields is None:
+        fields = list(results[0].keys())
+
+    output = io.StringIO()
+    writer = csv.DictWriter(output, fieldnames=fields, extrasaction='ignore')
+    writer.writeheader()
+    writer.writerows(results)
+    return output.getvalue()
+```
+
+**Upload as lookup file:**
+```python
+from falconpy import NGSIEM
+
+def upload_lookup(csv_path, filename="export.csv", repo="search-all"):
+    ngsiem = NGSIEM()
+    try:
+        response = ngsiem.upload_file(lookup_file=csv_path,
+                                      repository=repo)
+        return response["status_code"] == 200
+    finally:
+        import os
+        os.remove(csv_path)  # Always clean up /tmp
+```
+
+**Store in collection:**
+```python
+from falconpy import CustomStorage
+
+
+def _app_headers() -> dict:
+    app_id = os.environ.get("APP_ID")
+    if app_id:
+        return {"X-CS-APP-ID": app_id}
+    return {}
+
+
+def store_results(results, collection_name):
+    custom_storage = CustomStorage(ext_headers=_app_headers())
+    for record in results:
+        custom_storage.PutObject(body=record,
+                                 collection_name=collection_name,
+                                 object_key=record.get("id", str(hash(str(record)))))
+```
+
+**Workflow: Event Query → Lookup File (CEL expression):**
+```yaml
+actions:
+  QueryEvents:
+    id: event_query_action_id
+    properties:
+      query: "#event_simpleName=ProcessRollup2 | select(ComputerName, FileName)"
+      start: "-24h"
+      end: "now"
+  CreateLookup:
+    id: create_lookup_file_action_id
+    properties:
+      file_csv: ${data['QueryEvents.file_csv']}
+      filename: "process_export.csv"
+      repository: "search-all"
+```
+
+## Gotchas
+
+- **`extrasaction='ignore'`** is critical for CSV conversion. LogScale results contain metadata fields not in your fieldnames list — without this, `DictWriter` raises `ValueError`.
+- **Clean up `/tmp` in `finally` blocks.** Foundry function containers persist `/tmp` across invocations. Leaked files cause disk pressure and stale data.
+- **Lookup file limits:** 10 MB max file size, 5 uploads per 30 seconds. For larger exports, split into multiple files or use collections instead.
+- **`mode="sync"` vs `mode="async"`:** Sync blocks until results return (fast for <10K events). Async returns a job ID for polling (required for large/slow queries).
+- **Scope requirements:** `humio-auth-proxy:read` for queries, `humio-auth-proxy:write` for writing events or uploading files. Add both to manifest permissions.
+- **Workflow "Output files only":** If set to `true`, JSON result fields are empty — downstream actions can only use the CSV file. Set to `false` to preserve both.
+- **Live enrichment after upload:** Use `| match(file="export.csv", field=ComputerName)` in LogScale queries to join lookup columns to matching events.
+- **Collection writes are individual** — `PutObject` handles one record at a time. For bulk inserts, iterate. Consider batching in a function rather than doing one-per-workflow-step.

--- a/use-cases/python-functions.md
+++ b/use-cases/python-functions.md
@@ -78,14 +78,16 @@ response = api.execute_command_proxy(
 
 **Accessing collections from a function:**
 ```python
-from falconpy import APIHarnessV2
-api_client = APIHarnessV2()
+from falconpy import CustomStorage
+
+custom_storage = CustomStorage()
 # Write
-api_client.command("PutObject", body=data,
-    collection_name="my_collection", object_key=key)
+custom_storage.PutObject(body=data,
+                         collection_name="my_collection",
+                         object_key=key)
 # Read (returns bytes)
-result = api_client.command("GetObject",
-    collection_name="my_collection", object_key=key)
+result = custom_storage.GetObject(collection_name="my_collection",
+                                  object_key=key)
 json_data = json.loads(result.decode("utf-8"))
 ```
 


### PR DESCRIPTION
Adds the 10th skill (e2e-testing), a new use case, a new reference file, and promotes agentskills.io metadata across all skills.

**New skill: `e2e-testing`**
End-to-end testing for Foundry apps using `@crowdstrike/foundry-playwright`. Covers the 4-project pipeline (authenticate → install → test → uninstall), page objects, configuration screens, custom page objects, CI with GitHub Actions, and debugging with Playwright MCP.

**New use case: `ngsiem-query-export`**
Export Falcon Next-Gen SIEM query results to CSV/JSON via Foundry functions with pagination and scheduled workflow patterns. Source: [Tech Hub blog post](https://www.crowdstrike.com/tech-hub/ng-siem/exporting-falcon-next-gen-siem-query-results-to-csv-with-falcon-foundry/).

**New reference: `ui-development/references/foundry-js-sdk.md`**
SDK patterns for `@crowdstrike/foundry-js` — collections CRUD, workflows, LogScale, cloud functions. Source: [Tech Hub blog post](https://www.crowdstrike.com/tech-hub/ng-siem/getting-started-with-foundry-js-using-the-foundry-js-demo-app/).

**agentskills.io metadata promotion**
All 10 skills now have top-level `tags`, `author`, `license: MIT`, and `compatibility: Claude Code >=1.0` fields per the [agentskills.io](https://agentskills.io) open spec.

**Content additions to existing skills:**
- `development-workflow` — Expanded e2e testing section with credential config, non-SSO user requirement, app name alignment details
- `debugging-workflows` — Added visual debugging section (user screenshots, Playwright MCP, test failure artifacts)

Hook tests: 179/179 pass.