### PR TITLE
Release v1.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,6 @@
 {
   "name": "foundry-marketplace",
+  "description": "AI coding assistant skills for building CrowdStrike Falcon Foundry apps",
   "owner": {
     "name": "CrowdStrike"
   },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "crowdstrike-falcon-foundry",
       "source": "./",
       "description": "CrowdStrike Falcon Foundry development skills for building cybersecurity applications on the Falcon platform. Includes UI development, collections, functions, workflows, API integration, security patterns, and debugging workflows.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "author": {
         "name": "CrowdStrike"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "crowdstrike-falcon-foundry",
-  "description": "CrowdStrike Falcon Foundry development skills for building cybersecurity applications on the Falcon platform. Includes UI development, collections, functions, workflows, API integration, security patterns, and debugging workflows.",
+  "description": "CrowdStrike Falcon Foundry development skills for building cybersecurity applications on the Falcon platform. Includes UI development, collections, functions, workflows, API integration, security patterns, and debugging workflows. Swagger 2.0 specs are auto-converted to OpenAPI 3.0 via npx swagger2openapi (requires Node.js; network call to npm registry).",
   "version": "1.1.0",
   "author": {
     "name": "CrowdStrike"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "crowdstrike-falcon-foundry",
   "description": "CrowdStrike Falcon Foundry development skills for building cybersecurity applications on the Falcon platform. Includes UI development, collections, functions, workflows, API integration, security patterns, and debugging workflows.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "CrowdStrike"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [1.1.0] - 2026-05-12
+## [1.1.0] - 2026-05-13
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [1.1.0] - TBD
+## [1.1.0] - 2026-05-11
 
 ### Added
 
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Changed
 
 - **development-workflow** — Expanded e2e testing guidance with credential configuration details, non-SSO user requirement, and app name alignment.
+- **release.sh** — Added Step 8 documenting the Anthropic Plugin Marketplace update process (notify Anthropic of tag + SHA after each release).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 - **e2e-testing skill** — End-to-end testing for Foundry apps using `@crowdstrike/foundry-playwright`. Covers the 4-project pipeline (authenticate → install → test → uninstall), page objects, configuration screens, custom page objects, CI with GitHub Actions, and debugging with Playwright MCP.
 - **NGSIEM query export use case** — Export Falcon Next-Gen SIEM query results to CSV/JSON via Foundry functions with pagination and scheduled workflow patterns.
-- **Foundry-JS SDK reference** — `falcon.api.workflows`, `falcon.logscale`, `falcon.cloudFunction`, and collections CRUD patterns for `@crowdstrike/foundry-js` in `ui-development/references/foundry-js-sdk.md`.
+- **Foundry-JS reference** — `falcon.api.workflows`, `falcon.logscale`, `falcon.cloudFunction`, and collections CRUD patterns for `@crowdstrike/foundry-js` in `ui-development/references/foundry-js.md`.
 - **Visual debugging section** in debugging-workflows — Screenshot-based troubleshooting with Playwright MCP and test failure artifacts.
 - **agentskills.io metadata** — All skills now have top-level `tags`, `author`, `license`, and `compatibility` fields per the [agentskills.io](https://agentskills.io) open spec.
 
@@ -34,7 +34,7 @@ Initial public release of Falcon Foundry Skills — AI coding assistant skills f
 - **collections-development** — Design and implement Foundry collections with JSON Schema modeling, CRUD operations via CustomStorage, and access control patterns.
 - **functions-development** — Build serverless functions in Python or Go with FDK handler patterns, dependency management, and testing.
 - **functions-falcon-api** — Call CrowdStrike Falcon APIs from within Foundry functions using zero-argument FalconPy authentication.
-- **ui-development** — Build UI pages and extensions with React, Vue, or vanilla JS. Includes FalconJS SDK patterns, Shoelace theming, and iframe communication.
+- **ui-development** — Build UI pages and extensions with React, Vue, or vanilla JS. Includes Foundry-JS patterns, Shoelace theming, and iframe communication.
 - **workflows-development** — Design Falcon Fusion SOAR workflows with YAML specs, CEL expressions, loop/condition control flow, and platform action integration.
 - **debugging-workflows** — Systematic troubleshooting for CLI errors, deployment failures, blank pages, and runtime issues.
 - **security-patterns** — OAuth scoping, input validation, XSS prevention, CSP configuration, and secure coding patterns.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [1.1.0] - 2026-05-11
+## [1.1.0] - 2026-05-12
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ The skills include hooks that ensure the right skills get used:
 
 3. **`PreToolUse` hook (CLI guard)** — Validates all Bash commands to ensure Foundry CLI commands include `--no-prompt` flag (prevents `Error: EOF` failures) and blocks manual directory creation for app structure (prevents invalid `manifest.yml`). This enforcement is automatic and transparent — you'll only see it when it catches an error.
 
+Hooks observe prompts and tool I/O to keyword-match Foundry-specific actions; no data leaves the session.
+
 ## Skills
 
 | Skill | Purpose |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Falcon Foundry Skills
 
-![Version](https://img.shields.io/badge/version-1.0.0-blue)
+![Version](https://img.shields.io/badge/version-1.1.0-blue)
 [![CI](https://github.com/CrowdStrike/foundry-skills/actions/workflows/main.yml/badge.svg)](https://github.com/CrowdStrike/foundry-skills/actions/workflows/main.yml)
 
 AI coding assistant skills for building [CrowdStrike Falcon Foundry](https://www.crowdstrike.com/en-us/platform/next-gen-siem/falcon-foundry/) apps. Build Foundry apps from a natural language prompt — API integrations, workflows, UI pages, functions, and collections — all scaffolded with the Foundry CLI and deployed to the Falcon console.
@@ -333,6 +333,8 @@ gh release create v<version> --target main --title "v<version>" --generate-notes
 ```
 
 This generates release notes from merged PRs and saves them as a draft. Review and edit the notes at [github.com/CrowdStrike/foundry-skills/releases](https://github.com/CrowdStrike/foundry-skills/releases), then click **Publish** when ready.
+
+After publishing the release, notify Anthropic of the new tag and SHA so they can update the marketplace pin. Do not open PRs to `anthropics/claude-plugins-official` or re-submit through the plugin submission form.
 
 ## License
 

--- a/release.sh
+++ b/release.sh
@@ -185,7 +185,7 @@ main() {
   printf "\n${BLUE}Step 5: Commit and create PR${RESET}\n"
   local release_branch="release/v${NEXT_VERSION}"
   git checkout -b "$release_branch"
-  git add "$PLUGIN_JSON" "$MARKETPLACE_JSON" "$SCRIPT_DIR/README.md" "$SCRIPT_DIR/skills"/*/SKILL.md "$SCRIPT_DIR/CHANGELOG.md"
+  git add "$PLUGIN_JSON" "$MARKETPLACE_JSON" "$SCRIPT_DIR/README.md" "$SCRIPT_DIR/skills"/*/SKILL.md "$SCRIPT_DIR/CHANGELOG.md" "$SCRIPT_DIR/release.sh"
   git commit -m "Release v${NEXT_VERSION}"
   printf "${GREEN}✓${RESET} Committed v${NEXT_VERSION}\n"
 
@@ -201,6 +201,13 @@ main() {
   printf "This creates a draft release with auto-generated notes from merged PRs.\n"
   printf "Review and edit the notes at https://github.com/CrowdStrike/foundry-skills/releases,\n"
   printf "then click Publish when ready.\n\n"
+
+  printf "${BLUE}Step 8: Update Anthropic Plugin Marketplace${RESET}\n"
+  printf "\nAfter publishing the GitHub release, notify Anthropic of the new tag and SHA:\n"
+  printf "  Tag: v${NEXT_VERSION}\n"
+  printf "  SHA: \$(git rev-parse v${NEXT_VERSION})\n\n"
+  printf "Anthropic handles the marketplace pin bump internally. Do not open PRs to\n"
+  printf "anthropics/claude-plugins-official or re-submit through the plugin submission form.\n\n"
   printf "${GREEN}Done.${RESET}\n"
 }
 

--- a/skills/api-integrations/SKILL.md
+++ b/skills/api-integrations/SKILL.md
@@ -151,7 +151,7 @@ For autocomplete dropdown patterns and the HTTP Actions vs. Functions decision f
 
 ## Calling API Integrations
 
-UI extensions call API integrations through the Falcon JS SDK (sandboxed iframes block arbitrary HTTP requests). This pattern is from [foundry-sample-foundryjs-demo](https://github.com/CrowdStrike/foundry-sample-foundryjs-demo):
+UI extensions call API integrations through Foundry-JS (sandboxed iframes block arbitrary HTTP requests). This pattern is from [foundry-sample-foundryjs-demo](https://github.com/CrowdStrike/foundry-sample-foundryjs-demo):
 
 ```javascript
 import FalconApi from '@crowdstrike/foundry-js';

--- a/skills/api-integrations/SKILL.md
+++ b/skills/api-integrations/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: api-integrations
 description: Expose external APIs to Falcon Foundry via OpenAPI specs. TRIGGER when user asks to "create an API integration", "adapt an OpenAPI spec for Foundry", "expose an API to workflows", "connect to a third-party API", or runs `foundry api-integrations create`. Also trigger when user has an OpenAPI/Swagger spec and wants it working in Falcon Foundry. DO NOT TRIGGER when user wants to call Falcon platform APIs from function code — use functions-falcon-api instead.
-version: 1.0.0
-updated: 2026-04-29
+version: 1.1.0
+updated: 2026-05-11
 tags: [foundry, openapi, api, workflows]
 author: CrowdStrike
 license: MIT

--- a/skills/api-integrations/SKILL.md
+++ b/skills/api-integrations/SKILL.md
@@ -2,7 +2,7 @@
 name: api-integrations
 description: Expose external APIs to Falcon Foundry via OpenAPI specs. TRIGGER when user asks to "create an API integration", "adapt an OpenAPI spec for Foundry", "expose an API to workflows", "connect to a third-party API", or runs `foundry api-integrations create`. Also trigger when user has an OpenAPI/Swagger spec and wants it working in Falcon Foundry. DO NOT TRIGGER when user wants to call Falcon platform APIs from function code — use functions-falcon-api instead.
 version: 1.1.0
-updated: 2026-05-11
+updated: 2026-05-12
 tags: [foundry, openapi, api, workflows]
 author: CrowdStrike
 license: MIT

--- a/skills/api-integrations/SKILL.md
+++ b/skills/api-integrations/SKILL.md
@@ -2,7 +2,7 @@
 name: api-integrations
 description: Expose external APIs to Falcon Foundry via OpenAPI specs. TRIGGER when user asks to "create an API integration", "adapt an OpenAPI spec for Foundry", "expose an API to workflows", "connect to a third-party API", or runs `foundry api-integrations create`. Also trigger when user has an OpenAPI/Swagger spec and wants it working in Falcon Foundry. DO NOT TRIGGER when user wants to call Falcon platform APIs from function code — use functions-falcon-api instead.
 version: 1.1.0
-updated: 2026-05-12
+updated: 2026-05-13
 tags: [foundry, openapi, api, workflows]
 author: CrowdStrike
 license: MIT

--- a/skills/api-integrations/references/calling-patterns.md
+++ b/skills/api-integrations/references/calling-patterns.md
@@ -2,12 +2,12 @@
 
 Full examples for calling API integrations from UI extensions, Python functions, and Go functions.
 
-## UI Extensions (JavaScript / Falcon JS SDK)
+## UI Extensions (JavaScript / Foundry-JS)
 
 UI extensions call API integrations through `falcon.apiIntegration()`, not direct HTTP calls. Foundry UI extensions run in sandboxed iframes and cannot make arbitrary HTTP requests.
 
 ```javascript
-// React example using Falcon JS SDK
+// React example using Foundry-JS
 import FalconApi from '@crowdstrike/foundry-js';
 
 const falcon = new FalconApi();

--- a/skills/collections-development/SKILL.md
+++ b/skills/collections-development/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: collections-development
 description: Design JSON Schema collections and CRUD patterns for Falcon Foundry apps. TRIGGER when user asks to "create a collection", "define a JSON schema", "store data in Foundry", runs `foundry collections create`, or needs help with indexable fields, FQL queries, or collection access patterns. DO NOT TRIGGER for workflow YAML, function handlers, or UI components — use the appropriate sub-skill.
-version: 1.0.0
-updated: 2026-04-29
+version: 1.1.0
+updated: 2026-05-11
 tags: [foundry, collections, json-schema, nosql]
 author: CrowdStrike
 license: MIT

--- a/skills/collections-development/SKILL.md
+++ b/skills/collections-development/SKILL.md
@@ -2,7 +2,7 @@
 name: collections-development
 description: Design JSON Schema collections and CRUD patterns for Falcon Foundry apps. TRIGGER when user asks to "create a collection", "define a JSON schema", "store data in Foundry", runs `foundry collections create`, or needs help with indexable fields, FQL queries, or collection access patterns. DO NOT TRIGGER for workflow YAML, function handlers, or UI components — use the appropriate sub-skill.
 version: 1.1.0
-updated: 2026-05-11
+updated: 2026-05-12
 tags: [foundry, collections, json-schema, nosql]
 author: CrowdStrike
 license: MIT

--- a/skills/collections-development/SKILL.md
+++ b/skills/collections-development/SKILL.md
@@ -2,7 +2,7 @@
 name: collections-development
 description: Design JSON Schema collections and CRUD patterns for Falcon Foundry apps. TRIGGER when user asks to "create a collection", "define a JSON schema", "store data in Foundry", runs `foundry collections create`, or needs help with indexable fields, FQL queries, or collection access patterns. DO NOT TRIGGER for workflow YAML, function handlers, or UI components — use the appropriate sub-skill.
 version: 1.1.0
-updated: 2026-05-12
+updated: 2026-05-13
 tags: [foundry, collections, json-schema, nosql]
 author: CrowdStrike
 license: MIT

--- a/skills/debugging-workflows/SKILL.md
+++ b/skills/debugging-workflows/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: debugging-workflows
 description: Systematic troubleshooting for Falcon Foundry CLI errors, manifest validation failures, deploy failures, and development server issues. TRIGGER when user encounters CLI errors, `foundry ui run` not working, deploy failures, authentication issues, or any unexpected behavior during Foundry app development. Also trigger for headless/CI environment setup failures.
-version: 1.0.0
-updated: 2026-04-29
+version: 1.1.0
+updated: 2026-05-11
 tags: [foundry, debugging, cli, deployment]
 author: CrowdStrike
 license: MIT

--- a/skills/debugging-workflows/SKILL.md
+++ b/skills/debugging-workflows/SKILL.md
@@ -2,7 +2,7 @@
 name: debugging-workflows
 description: Systematic troubleshooting for Falcon Foundry CLI errors, manifest validation failures, deploy failures, and development server issues. TRIGGER when user encounters CLI errors, `foundry ui run` not working, deploy failures, authentication issues, or any unexpected behavior during Foundry app development. Also trigger for headless/CI environment setup failures.
 version: 1.1.0
-updated: 2026-05-11
+updated: 2026-05-12
 tags: [foundry, debugging, cli, deployment]
 author: CrowdStrike
 license: MIT

--- a/skills/debugging-workflows/SKILL.md
+++ b/skills/debugging-workflows/SKILL.md
@@ -2,7 +2,7 @@
 name: debugging-workflows
 description: Systematic troubleshooting for Falcon Foundry CLI errors, manifest validation failures, deploy failures, and development server issues. TRIGGER when user encounters CLI errors, `foundry ui run` not working, deploy failures, authentication issues, or any unexpected behavior during Foundry app development. Also trigger for headless/CI environment setup failures.
 version: 1.1.0
-updated: 2026-05-12
+updated: 2026-05-13
 tags: [foundry, debugging, cli, deployment]
 author: CrowdStrike
 license: MIT

--- a/skills/development-workflow/SKILL.md
+++ b/skills/development-workflow/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: development-workflow
 description: Orchestrates the complete Falcon Foundry app lifecycle from requirements through deployment. TRIGGER when user asks to "create a Foundry app", "build a Foundry app", "plan a Foundry app", runs any `foundry apps` CLI command, or discusses Foundry app architecture. DO NOT TRIGGER when user is working on a specific capability (UI, function, workflow, collection) within an existing app — use the appropriate sub-skill instead. This skill OWNS the entire Foundry development flow. Do not delegate Foundry app creation to superpowers:brainstorming or superpowers:writing-plans — those skills do not know about the Foundry CLI.
-version: 1.0.0
-updated: 2026-04-29
+version: 1.1.0
+updated: 2026-05-11
 tags: [foundry, lifecycle, cli, deployment]
 author: CrowdStrike
 license: MIT

--- a/skills/development-workflow/SKILL.md
+++ b/skills/development-workflow/SKILL.md
@@ -2,7 +2,7 @@
 name: development-workflow
 description: Orchestrates the complete Falcon Foundry app lifecycle from requirements through deployment. TRIGGER when user asks to "create a Foundry app", "build a Foundry app", "plan a Foundry app", runs any `foundry apps` CLI command, or discusses Foundry app architecture. DO NOT TRIGGER when user is working on a specific capability (UI, function, workflow, collection) within an existing app — use the appropriate sub-skill instead. This skill OWNS the entire Foundry development flow. Do not delegate Foundry app creation to superpowers:brainstorming or superpowers:writing-plans — those skills do not know about the Foundry CLI.
 version: 1.1.0
-updated: 2026-05-11
+updated: 2026-05-12
 tags: [foundry, lifecycle, cli, deployment]
 author: CrowdStrike
 license: MIT

--- a/skills/development-workflow/SKILL.md
+++ b/skills/development-workflow/SKILL.md
@@ -2,7 +2,7 @@
 name: development-workflow
 description: Orchestrates the complete Falcon Foundry app lifecycle from requirements through deployment. TRIGGER when user asks to "create a Foundry app", "build a Foundry app", "plan a Foundry app", runs any `foundry apps` CLI command, or discusses Foundry app architecture. DO NOT TRIGGER when user is working on a specific capability (UI, function, workflow, collection) within an existing app — use the appropriate sub-skill instead. This skill OWNS the entire Foundry development flow. Do not delegate Foundry app creation to superpowers:brainstorming or superpowers:writing-plans — those skills do not know about the Foundry CLI.
 version: 1.1.0
-updated: 2026-05-12
+updated: 2026-05-13
 tags: [foundry, lifecycle, cli, deployment]
 author: CrowdStrike
 license: MIT

--- a/skills/e2e-testing/SKILL.md
+++ b/skills/e2e-testing/SKILL.md
@@ -2,7 +2,7 @@
 name: e2e-testing
 description: End-to-end testing for Falcon Foundry apps using Playwright and @crowdstrike/foundry-playwright. TRIGGER when user asks to "add e2e tests", "add playwright tests", "write end-to-end tests", "test my app", or mentions "e2e", "playwright", or "end-to-end" in the context of testing a Foundry app. DO NOT TRIGGER during normal app creation, UI development, or function development. This skill is opt-in; not all apps need e2e tests.
 version: 1.1.0
-updated: 2026-05-11
+updated: 2026-05-12
 tags: [foundry, e2e, playwright, testing]
 author: CrowdStrike
 license: MIT

--- a/skills/e2e-testing/SKILL.md
+++ b/skills/e2e-testing/SKILL.md
@@ -2,7 +2,7 @@
 name: e2e-testing
 description: End-to-end testing for Falcon Foundry apps using Playwright and @crowdstrike/foundry-playwright. TRIGGER when user asks to "add e2e tests", "add playwright tests", "write end-to-end tests", "test my app", or mentions "e2e", "playwright", or "end-to-end" in the context of testing a Foundry app. DO NOT TRIGGER during normal app creation, UI development, or function development. This skill is opt-in; not all apps need e2e tests.
 version: 1.1.0
-updated: 2026-05-12
+updated: 2026-05-13
 tags: [foundry, e2e, playwright, testing]
 author: CrowdStrike
 license: MIT

--- a/skills/e2e-testing/SKILL.md
+++ b/skills/e2e-testing/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: e2e-testing
 description: End-to-end testing for Falcon Foundry apps using Playwright and @crowdstrike/foundry-playwright. TRIGGER when user asks to "add e2e tests", "add playwright tests", "write end-to-end tests", "test my app", or mentions "e2e", "playwright", or "end-to-end" in the context of testing a Foundry app. DO NOT TRIGGER during normal app creation, UI development, or function development. This skill is opt-in; not all apps need e2e tests.
-version: 1.0.0
-updated: 2026-04-29
+version: 1.1.0
+updated: 2026-05-11
 tags: [foundry, e2e, playwright, testing]
 author: CrowdStrike
 license: MIT

--- a/skills/e2e-testing/SKILL.md
+++ b/skills/e2e-testing/SKILL.md
@@ -434,7 +434,7 @@ All [CrowdStrike/foundry-sample-*](https://github.com/CrowdStrike?q=foundry-samp
 | [foundry-sample-charlotte-toolkit](https://github.com/CrowdStrike/foundry-sample-charlotte-toolkit/tree/main/e2e) | Charlotte AI toolkit |
 | [foundry-sample-collections-toolkit](https://github.com/CrowdStrike/foundry-sample-collections-toolkit/tree/main/e2e) | Collection CRUD |
 | [foundry-sample-detection-translation](https://github.com/CrowdStrike/foundry-sample-detection-translation/tree/main/e2e) | Detection extension |
-| [foundry-sample-foundryjs-demo](https://github.com/CrowdStrike/foundry-sample-foundryjs-demo/tree/main/e2e) | Foundry-JS SDK demo |
+| [foundry-sample-foundryjs-demo](https://github.com/CrowdStrike/foundry-sample-foundryjs-demo/tree/main/e2e) | Foundry-JS demo |
 | [foundry-sample-idp-notifications](https://github.com/CrowdStrike/foundry-sample-idp-notifications/tree/main/e2e) | IDP notifications |
 | [foundry-sample-insider-risk-sailpoint](https://github.com/CrowdStrike/foundry-sample-insider-risk-sailpoint/tree/main/e2e) | SailPoint integration |
 | [foundry-sample-insider-risk-workday](https://github.com/CrowdStrike/foundry-sample-insider-risk-workday/tree/main/e2e) | Workday integration |

--- a/skills/functions-development/SKILL.md
+++ b/skills/functions-development/SKILL.md
@@ -2,7 +2,7 @@
 name: functions-development
 description: Build serverless Go or Python functions for Falcon Foundry apps. TRIGGER when user asks to "create a function", "write a serverless function", "build backend logic", runs `foundry functions create`, or needs help with FDK handler patterns, function testing, or collection integration from functions. DO NOT TRIGGER for calling Falcon platform APIs from functions — use functions-falcon-api instead. DO NOT TRIGGER for workflow YAML or UI components.
 version: 1.1.0
-updated: 2026-05-12
+updated: 2026-05-13
 tags: [foundry, functions, serverless, python, go]
 author: CrowdStrike
 license: MIT

--- a/skills/functions-development/SKILL.md
+++ b/skills/functions-development/SKILL.md
@@ -2,7 +2,7 @@
 name: functions-development
 description: Build serverless Go or Python functions for Falcon Foundry apps. TRIGGER when user asks to "create a function", "write a serverless function", "build backend logic", runs `foundry functions create`, or needs help with FDK handler patterns, function testing, or collection integration from functions. DO NOT TRIGGER for calling Falcon platform APIs from functions — use functions-falcon-api instead. DO NOT TRIGGER for workflow YAML or UI components.
 version: 1.1.0
-updated: 2026-05-11
+updated: 2026-05-12
 tags: [foundry, functions, serverless, python, go]
 author: CrowdStrike
 license: MIT

--- a/skills/functions-development/SKILL.md
+++ b/skills/functions-development/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: functions-development
 description: Build serverless Go or Python functions for Falcon Foundry apps. TRIGGER when user asks to "create a function", "write a serverless function", "build backend logic", runs `foundry functions create`, or needs help with FDK handler patterns, function testing, or collection integration from functions. DO NOT TRIGGER for calling Falcon platform APIs from functions — use functions-falcon-api instead. DO NOT TRIGGER for workflow YAML or UI components.
-version: 1.0.0
-updated: 2026-04-29
+version: 1.1.0
+updated: 2026-05-11
 tags: [foundry, functions, serverless, python, go]
 author: CrowdStrike
 license: MIT

--- a/skills/functions-falcon-api/SKILL.md
+++ b/skills/functions-falcon-api/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: functions-falcon-api
 description: Call CrowdStrike Falcon platform APIs (detections, alerts, hosts, RTR) from within Foundry function handlers. TRIGGER when user asks to "call Falcon APIs from a function", "use FalconPy in a function", "use gofalcon in a function", or needs to integrate Falcon platform APIs within serverless function code. DO NOT TRIGGER when user wants to expose external third-party APIs to Foundry — use api-integrations instead.
-version: 1.0.0
-updated: 2026-04-29
+version: 1.1.0
+updated: 2026-05-11
 tags: [foundry, functions, falcon-api, falconpy, gofalcon]
 author: CrowdStrike
 license: MIT

--- a/skills/functions-falcon-api/SKILL.md
+++ b/skills/functions-falcon-api/SKILL.md
@@ -2,7 +2,7 @@
 name: functions-falcon-api
 description: Call CrowdStrike Falcon platform APIs (detections, alerts, hosts, RTR) from within Foundry function handlers. TRIGGER when user asks to "call Falcon APIs from a function", "use FalconPy in a function", "use gofalcon in a function", or needs to integrate Falcon platform APIs within serverless function code. DO NOT TRIGGER when user wants to expose external third-party APIs to Foundry — use api-integrations instead.
 version: 1.1.0
-updated: 2026-05-11
+updated: 2026-05-12
 tags: [foundry, functions, falcon-api, falconpy, gofalcon]
 author: CrowdStrike
 license: MIT

--- a/skills/functions-falcon-api/SKILL.md
+++ b/skills/functions-falcon-api/SKILL.md
@@ -2,7 +2,7 @@
 name: functions-falcon-api
 description: Call CrowdStrike Falcon platform APIs (detections, alerts, hosts, RTR) from within Foundry function handlers. TRIGGER when user asks to "call Falcon APIs from a function", "use FalconPy in a function", "use gofalcon in a function", or needs to integrate Falcon platform APIs within serverless function code. DO NOT TRIGGER when user wants to expose external third-party APIs to Foundry — use api-integrations instead.
 version: 1.1.0
-updated: 2026-05-12
+updated: 2026-05-13
 tags: [foundry, functions, falcon-api, falconpy, gofalcon]
 author: CrowdStrike
 license: MIT

--- a/skills/security-patterns/SKILL.md
+++ b/skills/security-patterns/SKILL.md
@@ -2,7 +2,7 @@
 name: security-patterns
 description: Security patterns for Falcon Foundry apps including OAuth scopes, RBAC, input validation, UI security, and credential management. TRIGGER when user asks to "configure OAuth scopes", "secure a Foundry app", "handle secrets", "add input validation", or needs to review a Foundry app for security concerns (XSS, CSP, credential management). Also trigger during pre-deployment security reviews.
 version: 1.1.0
-updated: 2026-05-11
+updated: 2026-05-12
 tags: [foundry, oauth, rbac, xss, csp]
 author: CrowdStrike
 license: MIT

--- a/skills/security-patterns/SKILL.md
+++ b/skills/security-patterns/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: security-patterns
 description: Security patterns for Falcon Foundry apps including OAuth scopes, RBAC, input validation, UI security, and credential management. TRIGGER when user asks to "configure OAuth scopes", "secure a Foundry app", "handle secrets", "add input validation", or needs to review a Foundry app for security concerns (XSS, CSP, credential management). Also trigger during pre-deployment security reviews.
-version: 1.0.0
-updated: 2026-04-29
+version: 1.1.0
+updated: 2026-05-11
 tags: [foundry, oauth, rbac, xss, csp]
 author: CrowdStrike
 license: MIT

--- a/skills/security-patterns/SKILL.md
+++ b/skills/security-patterns/SKILL.md
@@ -2,7 +2,7 @@
 name: security-patterns
 description: Security patterns for Falcon Foundry apps including OAuth scopes, RBAC, input validation, UI security, and credential management. TRIGGER when user asks to "configure OAuth scopes", "secure a Foundry app", "handle secrets", "add input validation", or needs to review a Foundry app for security concerns (XSS, CSP, credential management). Also trigger during pre-deployment security reviews.
 version: 1.1.0
-updated: 2026-05-12
+updated: 2026-05-13
 tags: [foundry, oauth, rbac, xss, csp]
 author: CrowdStrike
 license: MIT

--- a/skills/ui-development/SKILL.md
+++ b/skills/ui-development/SKILL.md
@@ -2,7 +2,7 @@
 name: ui-development
 description: Build UI pages and extensions for Falcon Foundry apps using React or Vue with the Shoelace design system and Foundry-JS SDK. TRIGGER when user asks to "create a UI page", "build a UI extension", "add a Shoelace component", "call an API from the UI", runs `foundry ui pages create` or `foundry ui run`, or needs help with Vite config, FalconJS SDK, or Falcon console theming. DO NOT TRIGGER for backend functions, workflow YAML, or collection schemas.
 version: 1.1.0
-updated: 2026-05-12
+updated: 2026-05-13
 tags: [foundry, ui, react, vue, shoelace]
 author: CrowdStrike
 license: MIT

--- a/skills/ui-development/SKILL.md
+++ b/skills/ui-development/SKILL.md
@@ -2,7 +2,7 @@
 name: ui-development
 description: Build UI pages and extensions for Falcon Foundry apps using React or Vue with the Shoelace design system and Foundry-JS SDK. TRIGGER when user asks to "create a UI page", "build a UI extension", "add a Shoelace component", "call an API from the UI", runs `foundry ui pages create` or `foundry ui run`, or needs help with Vite config, FalconJS SDK, or Falcon console theming. DO NOT TRIGGER for backend functions, workflow YAML, or collection schemas.
 version: 1.1.0
-updated: 2026-05-11
+updated: 2026-05-12
 tags: [foundry, ui, react, vue, shoelace]
 author: CrowdStrike
 license: MIT

--- a/skills/ui-development/SKILL.md
+++ b/skills/ui-development/SKILL.md
@@ -315,6 +315,7 @@ Run `foundry ui extensions list-sockets` to get the current list of available so
 | Dark/light theming, design tokens | [references/falcon-theming.md](references/falcon-theming.md) |
 | React component examples | [references/react-patterns.md](references/react-patterns.md) |
 | Vue component examples | [references/vue-patterns.md](references/vue-patterns.md) |
+| FalconJS SDK: workflows, LogScale, cloud functions, collections CRUD | [references/foundry-js-sdk.md](references/foundry-js-sdk.md) |
 | Framework selection, ExtensionMessaging, E2E testing, Extension Builder, CSP, dev server coordination | [references/advanced-patterns.md](references/advanced-patterns.md) |
 
 ## Use Cases

--- a/skills/ui-development/SKILL.md
+++ b/skills/ui-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ui-development
-description: Build UI pages and extensions for Falcon Foundry apps using React or Vue with the Shoelace design system and Foundry-JS SDK. TRIGGER when user asks to "create a UI page", "build a UI extension", "add a Shoelace component", "call an API from the UI", runs `foundry ui pages create` or `foundry ui run`, or needs help with Vite config, FalconJS SDK, or Falcon console theming. DO NOT TRIGGER for backend functions, workflow YAML, or collection schemas.
+description: Build UI pages and extensions for Falcon Foundry apps using React or Vue with the Shoelace design system and Foundry-JS. TRIGGER when user asks to "create a UI page", "build a UI extension", "add a Shoelace component", "call an API from the UI", runs `foundry ui pages create` or `foundry ui run`, or needs help with Vite config, Foundry-JS, or Falcon console theming. DO NOT TRIGGER for backend functions, workflow YAML, or collection schemas.
 version: 1.1.0
 updated: 2026-05-13
 tags: [foundry, ui, react, vue, shoelace]
@@ -17,7 +17,7 @@ metadata:
 >
 > If you are loading this skill, your role is **Foundry UI specialist**.
 >
-> You MUST implement UI components following Falcon design system patterns using Shoelace components and the Foundry-JS SDK.
+> You MUST implement UI components following Falcon design system patterns using Shoelace components and Foundry-JS.
 >
 > **IMMEDIATE ACTIONS REQUIRED:**
 > 1. Use Shoelace components with `falcon-shoelace` theme (NOT vanilla Shoelace or raw HTML)
@@ -25,7 +25,7 @@ metadata:
 > 3. Coordinate with `foundry ui run` for live development
 > 4. Apply iframe security patterns for all extensions
 
-Falcon Foundry UI pages and extensions use React or Vue with the Shoelace design system (Falcon-themed) and the Foundry-JS SDK for platform integration.
+Falcon Foundry UI pages and extensions use React or Vue with the Shoelace design system (Falcon-themed) and Foundry-JS for platform integration.
 
 ## Pages vs Extensions
 
@@ -124,7 +124,7 @@ For extended Shoelace component catalog and CSS customization, see [references/s
 
 For theming, dark/light mode switching, and design token values, see [references/falcon-theming.md](references/falcon-theming.md).
 
-## FalconJS SDK
+## Foundry-JS
 
 ```javascript
 import FalconApi from '@crowdstrike/foundry-js';
@@ -315,7 +315,7 @@ Run `foundry ui extensions list-sockets` to get the current list of available so
 | Dark/light theming, design tokens | [references/falcon-theming.md](references/falcon-theming.md) |
 | React component examples | [references/react-patterns.md](references/react-patterns.md) |
 | Vue component examples | [references/vue-patterns.md](references/vue-patterns.md) |
-| FalconJS SDK: workflows, LogScale, cloud functions, collections CRUD | [references/foundry-js-sdk.md](references/foundry-js-sdk.md) |
+| Foundry-JS: workflows, LogScale, cloud functions, collections CRUD | [references/foundry-js.md](references/foundry-js.md) |
 | Framework selection, ExtensionMessaging, E2E testing, Extension Builder, CSP, dev server coordination | [references/advanced-patterns.md](references/advanced-patterns.md) |
 
 ## Use Cases
@@ -326,7 +326,7 @@ For real-world implementation patterns, see:
 
 ## Reference Implementations
 
-- **[foundry-sample-foundryjs-demo](https://github.com/CrowdStrike/foundry-sample-foundryjs-demo)**: Comprehensive FalconJS SDK demo (API integrations, collections, workflows, LogScale, cloud functions, events, navigation, modals)
+- **[foundry-sample-foundryjs-demo](https://github.com/CrowdStrike/foundry-sample-foundryjs-demo)**: Comprehensive Foundry-JS demo (API integrations, collections, workflows, LogScale, cloud functions, events, navigation, modals)
 - **[foundry-sample-mitre](https://github.com/CrowdStrike/foundry-sample-mitre)**: Vue shared components, multi-view app
 - **[foundry-sample-collections-toolkit](https://github.com/CrowdStrike/foundry-sample-collections-toolkit)**: UI for collections
 - **[foundry-sample-functions-python](https://github.com/CrowdStrike/foundry-sample-functions-python)**: UI calling functions

--- a/skills/ui-development/SKILL.md
+++ b/skills/ui-development/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: ui-development
 description: Build UI pages and extensions for Falcon Foundry apps using React or Vue with the Shoelace design system and Foundry-JS SDK. TRIGGER when user asks to "create a UI page", "build a UI extension", "add a Shoelace component", "call an API from the UI", runs `foundry ui pages create` or `foundry ui run`, or needs help with Vite config, FalconJS SDK, or Falcon console theming. DO NOT TRIGGER for backend functions, workflow YAML, or collection schemas.
-version: 1.0.0
-updated: 2026-04-29
+version: 1.1.0
+updated: 2026-05-11
 tags: [foundry, ui, react, vue, shoelace]
 author: CrowdStrike
 license: MIT

--- a/skills/ui-development/references/advanced-patterns.md
+++ b/skills/ui-development/references/advanced-patterns.md
@@ -21,7 +21,7 @@
 ### UI Pages (Standalone Applications)
 - Technology selection: Vue vs React guidance
 - Shoelace design system integration
-- Foundry-JS SDK authentication patterns
+- Foundry-JS authentication patterns
 - Vite build system configuration
 
 ### UI Extensions (Console-Embedded Components)
@@ -260,7 +260,7 @@ ui:
 | "I can test API integration calls before deploying" | `foundry ui run` only serves UI locally — API integrations, collections, and functions must be deployed to the cloud first via `foundry apps deploy` |
 | "I can test without mocking Foundry SDK" | Real API calls in tests are slow, flaky, and environment-dependent |
 | "Iframe security is handled by the platform" | Extensions MUST validate message origins; platform provides the sandbox, you secure the communication |
-| "React/Vue patterns are transferable" | Foundry-JS SDK and Shoelace have specific integration patterns |
+| "React/Vue patterns are transferable" | Foundry-JS and Shoelace have specific integration patterns |
 | "I'll use the default Shoelace theme" | Vanilla Shoelace doesn't match Falcon console styling; `falcon-shoelace` is required for visual consistency and dark/light mode support |
 | "Dark mode support can come later" | The Falcon console ships with dark mode. Users see broken styling on day one if you skip it |
 

--- a/skills/ui-development/references/foundry-js.md
+++ b/skills/ui-development/references/foundry-js.md
@@ -1,6 +1,6 @@
-# foundry-js SDK Operations
+# Foundry-JS Operations
 
-SDK patterns for `@crowdstrike/foundry-js` beyond the React context/navigation covered in `react-patterns.md`. Source: [Getting Started with foundry-js](https://www.crowdstrike.com/tech-hub/ng-siem/getting-started-with-foundry-js-using-the-foundry-js-demo-app/).
+Patterns for `@crowdstrike/foundry-js` beyond the React context/navigation covered in `react-patterns.md`. Source: [Getting Started with foundry-js](https://www.crowdstrike.com/tech-hub/ng-siem/getting-started-with-foundry-js-using-the-foundry-js-demo-app/).
 
 ## Connection (Required First)
 

--- a/skills/ui-development/references/vue-patterns.md
+++ b/skills/ui-development/references/vue-patterns.md
@@ -2,7 +2,7 @@
 
 ## Page Component (Full Example)
 
-Vue 3 Composition API with Foundry-JS SDK:
+Vue 3 Composition API with Foundry-JS:
 
 ```vue
 <template>

--- a/skills/workflows-development/SKILL.md
+++ b/skills/workflows-development/SKILL.md
@@ -2,7 +2,7 @@
 name: workflows-development
 description: Create and configure Falcon Fusion SOAR workflow YAML for Falcon Foundry apps. TRIGGER when user asks to "create a workflow", "build an automation", "configure Fusion SOAR", "add an on-demand workflow", runs `foundry workflows create`, or needs help with Fusion YAML syntax, triggers, actions, or variable references. DO NOT TRIGGER for UI pages, functions, or collection schemas — use the appropriate sub-skill.
 version: 1.1.0
-updated: 2026-05-11
+updated: 2026-05-12
 tags: [foundry, workflows, fusion-soar, yaml]
 author: CrowdStrike
 license: MIT

--- a/skills/workflows-development/SKILL.md
+++ b/skills/workflows-development/SKILL.md
@@ -2,7 +2,7 @@
 name: workflows-development
 description: Create and configure Falcon Fusion SOAR workflow YAML for Falcon Foundry apps. TRIGGER when user asks to "create a workflow", "build an automation", "configure Fusion SOAR", "add an on-demand workflow", runs `foundry workflows create`, or needs help with Fusion YAML syntax, triggers, actions, or variable references. DO NOT TRIGGER for UI pages, functions, or collection schemas — use the appropriate sub-skill.
 version: 1.1.0
-updated: 2026-05-12
+updated: 2026-05-13
 tags: [foundry, workflows, fusion-soar, yaml]
 author: CrowdStrike
 license: MIT

--- a/skills/workflows-development/SKILL.md
+++ b/skills/workflows-development/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: workflows-development
 description: Create and configure Falcon Fusion SOAR workflow YAML for Falcon Foundry apps. TRIGGER when user asks to "create a workflow", "build an automation", "configure Fusion SOAR", "add an on-demand workflow", runs `foundry workflows create`, or needs help with Fusion YAML syntax, triggers, actions, or variable references. DO NOT TRIGGER for UI pages, functions, or collection schemas — use the appropriate sub-skill.
-version: 1.0.0
-updated: 2026-04-29
+version: 1.1.0
+updated: 2026-05-11
 tags: [foundry, workflows, fusion-soar, yaml]
 author: CrowdStrike
 license: MIT

--- a/test-skill.sh
+++ b/test-skill.sh
@@ -184,7 +184,7 @@ for i in $(seq 1 $RUNS); do
   FOUNDRY_SKIP_NAME_CONFIRM=1 env -u CLAUDECODE claude -p "$RUN_PROMPT" \
     ${PLUGIN_DIR_FLAGS[@]+"${PLUGIN_DIR_FLAGS[@]}"} \
     --dangerously-skip-permissions \
-    --model claude-4-6-opus \
+    --model opus \
     --verbose \
     --output-format stream-json \
     > "$LOG_FILE" 2>&1 &

--- a/test-skill.sh
+++ b/test-skill.sh
@@ -184,7 +184,7 @@ for i in $(seq 1 $RUNS); do
   FOUNDRY_SKIP_NAME_CONFIRM=1 env -u CLAUDECODE claude -p "$RUN_PROMPT" \
     ${PLUGIN_DIR_FLAGS[@]+"${PLUGIN_DIR_FLAGS[@]}"} \
     --dangerously-skip-permissions \
-    --model opus \
+    --model claude-opus-4-6 \
     --verbose \
     --output-format stream-json \
     > "$LOG_FILE" 2>&1 &

--- a/verify-apps.sh
+++ b/verify-apps.sh
@@ -626,7 +626,7 @@ printf "  Log: %s\n\n" "$LOG_FILE"
 
 env -u CLAUDECODE claude -p "$BROWSER_PROMPT" \
   --dangerously-skip-permissions \
-  --model claude-4-6-opus \
+  --model opus \
   --verbose \
   --output-format stream-json \
   > "$LOG_FILE" 2>&1 || true

--- a/verify-apps.sh
+++ b/verify-apps.sh
@@ -626,7 +626,7 @@ printf "  Log: %s\n\n" "$LOG_FILE"
 
 env -u CLAUDECODE claude -p "$BROWSER_PROMPT" \
   --dangerously-skip-permissions \
-  --model opus \
+  --model claude-opus-4-6 \
   --verbose \
   --output-format stream-json \
   > "$LOG_FILE" 2>&1 || true


### PR DESCRIPTION
Version bump to v1.1.0.

Adds marketplace update documentation to `release.sh` (Step 8) and README, documenting the process for notifying Anthropic of new tags after each release. Also includes `release.sh` in its own `git add` step so future script edits are captured automatically.