### PR TITLE
Document that foundry app commands must run from app root

### DIFF
--- a/skills/development-workflow/SKILL.md
+++ b/skills/development-workflow/SKILL.md
@@ -32,6 +32,8 @@ metadata:
 >
 > **CRITICAL: `--no-prompt` is supported by nearly all commands.** Always add `--no-prompt` to prevent interactive prompts that cause `Error: EOF` in non-interactive environments. Supported commands include: `apps create`, `apps validate`, `apps deploy`, `apps release`, `apps delete` (also needs `--force-delete`, but may still prompt interactively in some CLI versions — delete via Falcon App Manager UI if it hangs), `functions create`, `collections create`, `ui pages create`, `ui extensions create`, `rtr-scripts create`, `profile create`, `workflows create`, and `api-integrations create`. When unsure, run `foundry <command> --help` to check. When a CLI command fails, MUST NOT fall back to `mkdir` — fix the command and retry.
 >
+> **CRITICAL: All `foundry` app commands MUST run from the app root directory** (where `manifest.yml` lives). The CLI resolves manifest paths relative to `os.Getwd()`, not relative to the manifest's location. Running `foundry apps validate`, `foundry apps deploy`, or `foundry ui run` from a subdirectory (e.g., `ui/extensions/my-ext/`) causes doubled paths and misleading "file not found" errors. After `cd`-ing into a subdirectory for `npm install && npm run build`, always `cd` back to the app root before running any `foundry apps *` or `foundry ui *` command. Commands that work from anywhere: `foundry version`, `foundry profile *`, `foundry apps list-deployments`.
+>
 > **Superpowers skills MAY supplement** (TDD discipline, code review) but MUST NOT replace this workflow.
 
 This skill coordinates the full Falcon Foundry app lifecycle — from parsing requirements through scaffolding, implementation, and deployment. It delegates capability-specific work to sub-skills that know the platform details.
@@ -157,8 +159,12 @@ The CLI scaffolds structure but cannot generate app logic. Delegate to sub-skill
 ### Step 7: Final Build and Deploy
 
 ```bash
-# Build UI (required before deploy)
+# Build UI (required before deploy) — MUST cd back to app root afterward
 cd ui/pages/my-page && npm install && npm run build && cd ../../..
+# For extensions: cd ui/extensions/my-ext && npm install && npm run build && cd ../../..
+
+# IMPORTANT: Verify you are in the app root (where manifest.yml lives) before running
+# foundry apps/ui commands. The CLI resolves paths relative to cwd, not the manifest location.
 
 # Final deploy (run ONCE, never re-deploy to check status)
 foundry apps deploy --no-prompt --change-type Patch --change-log "Complete app"

--- a/skills/ui-development/SKILL.md
+++ b/skills/ui-development/SKILL.md
@@ -249,6 +249,8 @@ For full Vue component examples, see [references/vue-patterns.md](references/vue
 - **`foundry ui run`**: Serves only the UI in Falcon console dev mode (port 25678). Use during UI-focused development.
 - **`foundry apps run`**: Starts the full app locally (validates manifest on startup). Use when testing UI + functions + integrations together.
 
+**CRITICAL: Run from the app root directory.** Both `foundry ui run` and `foundry apps run` resolve manifest paths relative to `os.Getwd()`. After `cd`-ing into a UI page/extension directory for `npm install && npm run build`, always `cd` back to the app root before running any `foundry` app commands. Running from a subdirectory causes "file not found" or doubled-path errors.
+
 If the UI calls API integrations, collections, or functions, deploy those backend capabilities first via `foundry apps deploy`. `foundry ui run` only serves UI assets locally — backend capabilities resolve from the cloud.
 
 ### Development Mode vs Preview Mode
@@ -295,6 +297,7 @@ Run `foundry ui extensions list-sockets` to get the current list of available so
 
 ## Common Pitfalls
 
+- **Running `foundry` commands from a UI subdirectory.** After `cd ui/extensions/my-ext && npm install && npm run build`, you MUST `cd` back to the app root before running `foundry apps validate`, `foundry apps deploy`, or `foundry ui run`. The CLI resolves manifest paths relative to cwd — running from a subdirectory produces doubled paths like `ui/extensions/my-ext/ui/extensions/my-ext/src/dist/index.html`.
 - **NEVER edit manifest.yml `path` or `entrypoint` values.** The CLI sets these correctly. The format `ui/extensions/my-ext/src/dist/index.html` is NOT a doubled path — it is correct. If you see a deploy path error, you likely changed `vite.config.js` — revert your changes.
 - **NEVER modify `vite.config.js`.** The blueprint is turnkey. Do not change `base: './'` to `''` or anything else. Do not change `root: 'src'`. Do not remove `noAttr()`. Just edit your React/JS code and deploy.
 - **Omitting `--sockets` on extension create.** This launches an interactive picker that hangs with `Error: EOF`. Always provide `--sockets "socket.id"` on the command line. Run `foundry ui extensions list-sockets` to see available sockets — do not guess or fabricate socket names.


### PR DESCRIPTION
Running `foundry apps validate`, `foundry apps deploy`, or `foundry ui run` from a subdirectory (e.g., after `cd ui/extensions/my-ext && npm install && npm run build`) produces doubled paths and misleading "file not found" errors. The CLI resolves manifest paths relative to the current working directory, not relative to the manifest's location.

Confirmed via empirical testing against `foundry-sample-foundryjs-demo` from multiple subdirectories.

Changes:
- `development-workflow/SKILL.md`: Added CRITICAL note to system injection block and clarified Step 7 build instructions
- `ui-development/SKILL.md`: Added warning to Development Servers section and new Common Pitfalls entry