### PR TITLE
Add collection write error pitfalls and blank page troubleshooting

### DIFF
--- a/skills/collections-development/SKILL.md
+++ b/skills/collections-development/SKILL.md
@@ -310,6 +310,8 @@ Collections can be accessed directly via the CrowdStrike API (outside of functio
 - **Not configuring workflow share settings.** Set `workflow_integration.system_action: true` for app-only workflow access, or `false` to also expose collections as Falcon Fusion SOAR actions.
 - **Trying to delete collections via CLI.** Collections can only be deleted from the Falcon Foundry UI.
 - **Trying to manage objects via CLI.** Collection CRUD requires the CrowdStrike API or `foundry-js` SDK.
+- **Schema field names must match exactly.** If a field name in your write payload doesn't match the collection schema (e.g., writing `score` when the schema defines `severity`), the write fails and returns errors in the response body — but the SDK does not throw. Without checking `result.errors`, the failure is invisible. Always read the collection schema file before writing seed data; verify required fields, enum values, and exact field names.
+- **Not checking write responses for errors.** The SDK does not throw on server-side validation failures. Always check `result?.errors?.length` after write operations — errors include specific messages like `"missing property 'severity'"` or `"value must be one of 'low', 'medium', 'high', 'critical'"`. Verify persistence with a follow-up read or list call.
 
 ## Reading Guide
 

--- a/skills/debugging-workflows/SKILL.md
+++ b/skills/debugging-workflows/SKILL.md
@@ -174,6 +174,8 @@ The CI environment has no `~/.config/foundry/configuration.yml`. Set environment
 | Page 404 on new cloud only | Cloud-specific IDs in manifest | Strip IDs with yq before deploying to new cloud |
 | Blank page, no CORS errors | Vite `root` changed from `src` | Restore `root: 'src'` in vite.config.js |
 | Blank page with CORS errors | `noAttr()` removed from vite.config.js | Restore the `noAttr()` plugin in vite.config.js |
+| Blank page, no errors in console | `falcon.connect()` not awaited | The platform iframe stays blank until the postMessage handshake completes — add `await falcon.connect()` before any rendering |
+| Data not appearing after writes | Schema mismatch or missing error check | Verify field names/enums match schema exactly; check `result?.errors?.length` after writes |
 | Dialog white background in dark mode | Shoelace panel defaults | Override `--sl-panel-background-color` with `var(--ground-floor)` |
 | App install fails with no detail | Workflow CEL expression error | Test API integration in console, then inspect workflow editor for errors |
 


### PR DESCRIPTION
Adds validated pitfall warnings for collection write operations and expands the debugging troubleshooting table.

Changes:
- collections-development: Two new Common Pitfalls entries warning that schema field mismatches and invalid values return errors in the response body without throwing
- debugging-workflows: Two new table rows for blank page from missing falcon.connect() and data not appearing from schema mismatches

Validated by deploying a Vanilla JS test app and confirming each failure mode with Playwright. Also disproved a claim that CSP blocks inline scripts. The platform always includes 'unsafe-inline' in script-src.