### PR TITLE
Add skill size budget validation to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,19 +63,20 @@ jobs:
       - name: Validate skill size budgets
         run: |
           fail=0
-          warn=0
           total_desc_chars=0
+          max_tokens=5500
 
           for skill in skills/*/SKILL.md; do
             name=$(basename "$(dirname "$skill")")
             chars=$(wc -c < "$skill")
             approx_tokens=$((chars / 4))
+            pct=$((approx_tokens * 100 / max_tokens))
 
-            if [ "$approx_tokens" -gt 5500 ]; then
-              echo "FAIL: $name SKILL.md ~${approx_tokens} tokens (max 5500)"
+            if [ "$approx_tokens" -gt "$max_tokens" ]; then
+              echo "FAIL: $name ~${approx_tokens} tokens (${pct}% of ${max_tokens} limit)"
               fail=1
             elif [ "$approx_tokens" -gt 4500 ]; then
-              echo "WARN: $name SKILL.md ~${approx_tokens} tokens (approaching 5500 limit)"
+              echo "WARN: $name ~${approx_tokens} tokens (${pct}% of ${max_tokens} limit)"
             fi
 
             desc=$(sed -n 's/^description: *//p' "$skill")
@@ -88,8 +89,10 @@ jobs:
             fi
           done
 
+          desc_budget=8000
+          desc_pct=$((total_desc_chars * 100 / desc_budget))
           echo ""
-          echo "Total description budget: ${total_desc_chars} chars across $(ls -d skills/*/SKILL.md | wc -l) skills"
+          echo "Description budget: ${total_desc_chars} / ~${desc_budget} chars (${desc_pct}%) — 1% of 200k context at ~4 chars/token"
           exit $fail
       - name: Validate hook scripts exist
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,6 +60,37 @@ jobs:
             done
           done
           exit $fail
+      - name: Validate skill size budgets
+        run: |
+          fail=0
+          warn=0
+          total_desc_chars=0
+
+          for skill in skills/*/SKILL.md; do
+            name=$(basename "$(dirname "$skill")")
+            chars=$(wc -c < "$skill")
+            approx_tokens=$((chars / 4))
+
+            if [ "$approx_tokens" -gt 5500 ]; then
+              echo "FAIL: $name SKILL.md ~${approx_tokens} tokens (max 5500)"
+              fail=1
+            elif [ "$approx_tokens" -gt 4500 ]; then
+              echo "WARN: $name SKILL.md ~${approx_tokens} tokens (approaching 5500 limit)"
+            fi
+
+            desc=$(sed -n 's/^description: *//p' "$skill")
+            desc_len=${#desc}
+            total_desc_chars=$((total_desc_chars + desc_len))
+
+            if [ "$desc_len" -gt 1536 ]; then
+              echo "FAIL: $name description ${desc_len} chars (max 1536)"
+              fail=1
+            fi
+          done
+
+          echo ""
+          echo "Total description budget: ${total_desc_chars} chars across $(ls -d skills/*/SKILL.md | wc -l) skills"
+          exit $fail
       - name: Validate hook scripts exist
         run: |
           fail=0


### PR DESCRIPTION
Adds a CI check that prevents skills from gradually bloating past Claude Code's performance-sensitive size limits.

Checks:
- SKILL.md approximate token count (warn at 4,500, fail at 5,500) based on the ~5,000 token compaction retention limit
- Frontmatter description length (fail at 1,536 chars) based on the per-skill description cap
- Total description budget usage as a percentage (1% of 200k context window at ~4 chars/token)

Currently all skills pass. Two emit warnings (e2e-testing at 95% and workflows-development at 84%) which is informational only.

Size limits are from Claude Code's skill content lifecycle documentation (https://code.claude.com/docs/en/skills#skill-content-lifecycle): after compaction, each skill retains the first 5,000 tokens within a shared 25,000-token budget, and each description is capped at 1,536 characters. Run `/doctor` in Claude Code to see live budget usage.