### PR TITLE
Add console navigation to UI extension socket table

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -4,6 +4,7 @@
   "MD012": false,
   "MD013": false,
   "MD022": false,
+  "MD024": { "siblings_only": true },
   "MD028": false,
   "MD031": false,
   "MD032": false,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.2.0] - TBD
+
+### Added
+
+- **Foundry-JS API integration pattern** — Added the `falcon.apiIntegration().execute()` pattern for calling external APIs from the UI to `ui-development/references/foundry-js.md`, with response structure and a cross-reference to Python/Go function examples.
+- **Extension socket navigation** — The UI socket table now includes a console navigation column and the `identity.detections.details` socket, with verified paths to each socket's detail panel.
+
+### Changed
+
+- **collections-development** — Added pitfalls warning that schema field mismatches and invalid enum values return errors in the response body without throwing, so writes must check `result.errors`.
+- **debugging-workflows** — Added troubleshooting rows for blank pages from an un-awaited `falcon.connect()` and data not appearing after writes due to schema mismatches.
+- **development-workflow, ui-development** — Documented that `foundry apps validate`, `deploy`, and `ui run` must run from the app root; running from a subdirectory produces doubled paths and misleading file-not-found errors.
+
 ## [1.1.0] - 2026-05-13
 
 ### Added

--- a/skills/ui-development/SKILL.md
+++ b/skills/ui-development/SKILL.md
@@ -284,16 +284,17 @@ window.addEventListener('message', (event: MessageEvent) => {
 
 ## Extension Socket Locations
 
-Run `foundry ui extensions list-sockets` to get the current list of available sockets. Use the **technical ID** (not human-readable name) with `--sockets`:
+Run `foundry ui extensions list-sockets` to get the current list of available sockets. Use the **technical ID** (not human-readable name) with `--sockets`. The extension renders in the detail panel reached by the navigation below — open an individual record (detection, case, host, lead, or execution) to see it.
 
-| Display Name | Technical ID for `--sockets` |
-|-------------|------------------------------|
-| Automated leads details | `automated-leads.leads.details` |
-| Endpoint detection details | `activity.detections.details` |
-| Host management host details | `hosts.host.panel` |
-| Next-Gen SIEM cases details | `xdr.cases.panel` |
-| Next-Gen SIEM workbench details | `ngsiem.workbench.details` |
-| Workflow execution details | `workflows.executions.execution.details` |
+| Display Name | Technical ID for `--sockets` | Console Navigation |
+|-------------|------------------------------|--------------------|
+| Endpoint detection details | `activity.detections.details` | Endpoint security › Monitor › Endpoint detections |
+| Identity Protection detection details | `identity.detections.details` | Identity protection › Detections |
+| Next-Gen SIEM cases details | `xdr.cases.panel` | Next-Gen SIEM › Cases |
+| Next-Gen SIEM workbench details | `ngsiem.workbench.details` | Next-Gen SIEM › Cases › open a case › workbench graph canvas › click a node |
+| Host management host details | `hosts.host.panel` | Host setup and management › Host management |
+| Automated leads details | `automated-leads.leads.details` | Next-Gen SIEM › Automated leads |
+| Workflow execution details | `workflows.executions.execution.details` | Fusion SOAR › Workflows › open an execution |
 
 ## Common Pitfalls
 


### PR DESCRIPTION
The UI extension socket table listed socket IDs but gave no indication of where each extension actually renders in the Falcon console — and was missing the `identity.detections.details` socket entirely. Finding a socket's location was difficult, especially for developers new to the console.

This adds a Console Navigation column and the missing identity socket. Paths were verified two ways: six against the live Falcon console, and the NGSIEM workbench socket against the `@crowdstrike/foundry-playwright` `SocketNavigationPage` flow (open a case, wait for the graph canvas, search for and click a node).

Also backfills the CHANGELOG with a `1.2.0` TBD section covering user-facing changes merged since 1.1.0, and sets markdownlint MD024 to `siblings_only` so the Keep a Changelog format's repeated `Added`/`Changed` headings lint clean.

Changes:
- `ui-development/SKILL.md`: Console Navigation column + `identity.detections.details` row
- `CHANGELOG.md`: new 1.2.0 TBD section
- `.markdownlint.json`: MD024 `siblings_only`