### PR TITLE
Enforce --change-type on foundry apps deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
+- **Deploy command validation** — The CLI guard hook now catches missing `--change-type` and `--change-log` flags on `foundry apps deploy`, preventing a 500 error from the Foundry API.
 - **Foundry-JS API integration pattern** — Added the `falcon.apiIntegration().execute()` pattern for calling external APIs from the UI to `ui-development/references/foundry-js.md`, with response structure and a cross-reference to Python/Go function examples.
 - **Extension socket navigation** — The UI socket table now includes a console navigation column and the `identity.detections.details` socket, with verified paths to each socket's detail panel.
 

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ foundry ui extensions create --name "X" --from-template React --sockets "activit
 foundry functions create --name "X" --language python --no-prompt              # Add function
 foundry collections create --name "X" --schema /tmp/schema.json --no-prompt   # Add collection
 foundry workflows create --name "X" --spec /tmp/workflow.yaml --no-prompt     # Add workflow
-foundry apps deploy                                              # Deploy to cloud
+foundry apps deploy --change-type Patch --change-log "msg" --no-prompt  # Deploy to cloud
 foundry apps release                                             # Release to catalog
 ```
 

--- a/hooks/foundry-cli-guard.sh
+++ b/hooks/foundry-cli-guard.sh
@@ -8,9 +8,10 @@
 #
 # Prevents common failures:
 # 1. Running Foundry CLI commands without --no-prompt (causes Error: EOF)
-# 2. Running ui extensions create without --sockets (interactive picker hangs)
-# 3. Using mkdir/touch to create app structure (causes invalid manifests)
-# 4. Creating resources without user confirmation of the name
+# 2. Running foundry apps deploy without --change-type (causes 500 error)
+# 3. Running ui extensions create without --sockets (interactive picker hangs)
+# 4. Using mkdir/touch to create app structure (causes invalid manifests)
+# 5. Creating resources without user confirmation of the name
 #
 # Receives JSON on stdin with hook_event_name and tool-specific fields.
 # Outputs JSON with additionalContext (advisory nudge, not blocking).
@@ -52,6 +53,30 @@ if echo "$COMMAND" | grep -qE 'foundry\s+apps\b.*\b(create|validate|release|dele
       hookSpecificOutput: {
         hookEventName: "PreToolUse",
         additionalContext: "The command is missing --no-prompt. Foundry CLI create/release commands run non-interactively in Claude Code and will hang with Error: EOF without it. Add --no-prompt before retrying. Example: foundry apps create --name \"app-name\" --no-prompt"
+      }
+    }'
+    exit 0
+  fi
+fi
+
+# Check for foundry apps deploy without --change-type
+# Omitting --change-type causes a 500 error (server-side panic) because the
+# Foundry API requires a change_type field in deploy requests.
+if echo "$COMMAND" | grep -qE 'foundry\s+apps\s+deploy\b'; then
+  if ! echo "$COMMAND" | grep -qF -- '--change-type'; then
+    jq -n '{
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        additionalContext: "The command is missing --change-type. Foundry apps deploy requires --change-type and --change-log to avoid a 500 error. Add both flags before retrying. Example: foundry apps deploy --change-type Patch --change-log \"description of changes\" --no-prompt"
+      }
+    }'
+    exit 0
+  fi
+  if ! echo "$COMMAND" | grep -qF -- '--change-log'; then
+    jq -n '{
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        additionalContext: "The command is missing --change-log. Foundry apps deploy requires --change-type and --change-log. Add both flags before retrying. Example: foundry apps deploy --change-type Patch --change-log \"description of changes\" --no-prompt"
       }
     }'
     exit 0

--- a/test-hooks.sh
+++ b/test-hooks.sh
@@ -922,6 +922,24 @@ JSON=$(jq -n '{hook_event_name: "PreToolUse", tool_name: "Bash", tool_input: {co
 OUTPUT=$(run_hook "$GUARD" "$JSON")
 assert_empty "$OUTPUT" "6.3  apps deploy → pass (no --no-prompt needed)"
 
+# 6.3b — foundry apps deploy without --change-type → advisory
+cleanup
+JSON=$(jq -n '{hook_event_name: "PreToolUse", tool_name: "Bash", tool_input: {command: "foundry apps deploy --no-prompt"}}')
+OUTPUT=$(run_hook "$GUARD" "$JSON")
+assert_contains "$OUTPUT" "missing --change-type" "6.3b apps deploy without --change-type → advisory"
+
+# 6.3c — foundry apps deploy without --change-log → advisory
+cleanup
+JSON=$(jq -n '{hook_event_name: "PreToolUse", tool_name: "Bash", tool_input: {command: "foundry apps deploy --change-type Patch --no-prompt"}}')
+OUTPUT=$(run_hook "$GUARD" "$JSON")
+assert_contains "$OUTPUT" "missing --change-log" "6.3c apps deploy without --change-log → advisory"
+
+# 6.3d — bare foundry apps deploy (no flags at all) → advisory
+cleanup
+JSON=$(jq -n '{hook_event_name: "PreToolUse", tool_name: "Bash", tool_input: {command: "foundry apps deploy"}}')
+OUTPUT=$(run_hook "$GUARD" "$JSON")
+assert_contains "$OUTPUT" "missing --change-type" "6.3d bare apps deploy → advisory"
+
 # 6.4 — foundry ui pages create without --no-prompt → advisory
 cleanup
 JSON=$(jq -n '{hook_event_name: "PreToolUse", tool_name: "Bash", tool_input: {command: "foundry ui pages create --name MyPage --from-template React"}}')


### PR DESCRIPTION
The CLI guard hook now catches missing `--change-type` and `--change-log` flags on `foundry apps deploy` commands. Without these flags the Foundry API panics and returns a 500 error.

Changes:
- **hooks/foundry-cli-guard.sh**: Added validation that fires an advisory when `foundry apps deploy` is missing `--change-type` or `--change-log`
- **README.md**: Fixed the bare `foundry apps deploy` example to include the required flags
- **test-hooks.sh**: Added 3 test cases covering missing `--change-type`, missing `--change-log`, and a completely bare deploy command