### PR TITLE
Document navigateTo default target (_self) from foundry-js source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Changed
 
+- **ui-development** — Documented that `navigateTo` defaults `target` to `_self` when omitted (navigates in the same tab). Confirmed from foundry-js source.
 - **collections-development** — Added pitfalls warning that schema field mismatches and invalid enum values return errors in the response body without throwing, so writes must check `result.errors`.
 - **debugging-workflows** — Added troubleshooting rows for blank pages from an un-awaited `falcon.connect()` and data not appearing after writes due to schema mismatches.
 - **development-workflow, ui-development** — Documented that `foundry apps validate`, `deploy`, and `ui run` must run from the app root; running from a subdirectory produces doubled paths and misleading file-not-found errors.

--- a/skills/ui-development/references/foundry-js.md
+++ b/skills/ui-development/references/foundry-js.md
@@ -159,7 +159,9 @@ function App() {
 Links that navigate outside your app use `falcon.navigation.navigateTo()`. The `target` option controls where the link opens:
 
 - `target: "_blank"` — opens in a new browser tab
-- `target: "_self"` — navigates the Falcon console in the same tab
+- `target: "_self"` (default) — navigates the Falcon console in the same tab
+
+When `target` is omitted, it defaults to `_self`.
 
 ```tsx
 function ExternalLink({ href, children, newTab = true }) {


### PR DESCRIPTION
Confirmed from foundry-js `src/lib/navigation.ts` that omitting the `target` parameter defaults to `_self` (navigates the Falcon console in the same tab). Updated the ui-development skill reference to document this default.