### PR TITLE
Fix inclusive terminology, sync test script improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - **debugging-workflows** — Added troubleshooting rows for blank pages from an un-awaited `falcon.connect()` and data not appearing after writes due to schema mismatches.
 - **development-workflow, ui-development** — Documented that `foundry apps validate`, `deploy`, and `ui run` must run from the app root; running from a subdirectory produces doubled paths and misleading file-not-found errors.
 
+### Fixed
+
+- **Inclusive terminology** — Changed "Whitelist approach" to "Allowlist approach" in security-examples.md.
+- **verify-apps.sh extension verification** — Instructions now scroll to find the accordion, expand it, wait for the iframe to load, and check for content inside — matching the `expandExtensionInSocket()` pattern from `@crowdstrike/foundry-playwright`.
+- **test-skill.sh warmup** — Use `--model haiku` for the API health check to avoid wasting Opus tokens on a connectivity test.
+- **tail-test.sh** — Suppress `find` stderr when test directories don't exist yet.
+
 ## [1.1.0] - 2026-05-13
 
 ### Added

--- a/skills/security-patterns/references/security-examples.md
+++ b/skills/security-patterns/references/security-examples.md
@@ -38,7 +38,7 @@ import shlex
 def safe_command_execution(user_input: str) -> str:
     """Safe execution avoiding command injection"""
 
-    # Whitelist approach - only allow specific commands
+    # Allowlist approach - only allow specific commands
     allowed_commands = {
         'ping': ['ping', '-c', '1'],
         'nslookup': ['nslookup']

--- a/test-skill.sh
+++ b/test-skill.sh
@@ -138,7 +138,8 @@ find_app_dir() {
 # API health check: send a minimal request to verify connectivity before burning tokens
 check_api_health() {
   # Use claude with a trivial prompt — just check if it exits successfully
-  env -u CLAUDECODE claude -p "Reply with OK" > /dev/null 2>&1
+  env -u CLAUDECODE claude -p "Reply with OK" \
+    --model haiku > /dev/null 2>&1
   return $?
 }
 

--- a/verify-apps.sh
+++ b/verify-apps.sh
@@ -524,10 +524,14 @@ for idx in $(seq 0 $((APP_COUNT - 1))); do
    - Navigate: ${SOCKET_NAV}
    - Wait for the page to load
    - ${SOCKET_INTERACT}
-   - Look for the extension panel labeled '${APP_NAME}' or similar (may be a collapsible section or tab in the details sidebar)
-   - If you see the extension panel (even if empty or showing an error fetching data), note 'UI: PASS'
-   - If no extension panel appears after waiting, note 'UI: FAIL (extension not visible in socket)'
-   - Take a screenshot showing the details view with the extension panel"
+   - Look for the extension panel button labeled '${APP_NAME}' or similar (a collapsible accordion section in the details sidebar)
+   - Scroll down if needed — extensions are often at the bottom of the panel (press End key multiple times)
+   - **Expand the extension**: Check if the button has aria-expanded='false' or is collapsed. Click it to expand.
+   - **Wait for iframe content**: After expanding, wait for an iframe (typically iframe[name='portal']) to appear and load inside the extension panel. This is where the extension UI renders.
+   - **Verify content**: Check inside the iframe for meaningful content — a table, list, error message, or loading indicator. Take a screenshot showing the expanded extension with its iframe content.
+   - If the extension expands and shows content (even an error or loading state), note 'UI: PASS'
+   - If the extension button exists but iframe never loads or is blank after 15 seconds, note 'UI: FAIL (iframe empty)'
+   - If no extension panel appears after scrolling and waiting, note 'UI: FAIL (extension not visible in socket)'"
   elif [ "$UI_TYPE" = "page" ]; then
     UI_INSTRUCTIONS="2. **Verify UI (App Page)**
    - After install, look for the app in Custom Apps (hamburger menu → Falcon Foundry → Custom Apps) or check for a 'Launch' / 'Open' button on the app details page


### PR DESCRIPTION
Syncs test script improvements from the internal repo and fixes terminology.

**Fixes:**
- `security-examples.md`: "Whitelist approach" → "Allowlist approach" (inclusive terminology)
- `verify-apps.sh`: Extension verification now scrolls to find the accordion, expands it, waits for the iframe to load, and checks for content inside — matching the `expandExtensionInSocket()` pattern from `@crowdstrike/foundry-playwright`
- `test-skill.sh`: Use `--model haiku` for the API health check warmup to avoid wasting Opus tokens on a connectivity test
- `tail-test.sh`: Suppress `find` stderr when test directories don't exist yet