### PR TITLE
Add APIIntegrations.execute_command_proxy pattern + fix trigger variable syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- **functions-development** — Added `APIIntegrations().execute_command_proxy()` code examples showing how to call registered third-party API integrations from function code. Includes request body/params patterns, explanation of why the platform proxy is required, and references to 3 sample repos. Added pitfall warning against making raw HTTP calls when an integration is registered.
+
 ## [1.2.0] - 2026-06-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 - **functions-development** — Added `APIIntegrations().execute_command_proxy()` code examples showing how to call registered third-party API integrations from function code. Includes request body/params patterns, explanation of why the platform proxy is required, and references to 3 sample repos. Added pitfall warning against making raw HTTP calls when an integration is registered.
 
+### Fixed
+
+- **workflows-development** — Fixed incorrect trigger parameter variable syntax. Was `${data['trigger.param_name']}`, corrected to `${data['param_name']}` (no prefix). Validated against foundry-sample-foundryjs-demo, security-skills (20+ workflows), and all other sample repos that consistently use direct parameter names.
+
 ## [1.2.0] - 2026-06-03
 
 ### Added

--- a/skills/functions-development/SKILL.md
+++ b/skills/functions-development/SKILL.md
@@ -194,6 +194,57 @@ falcon = Alerts()  # Auth is automatic — do not pass credentials
 
 FalconPy already reads env vars internally, so writing a `get_falcon_client()` wrapper that manually reads credentials adds no value and breaks context auth in the cloud.
 
+### Calling Registered API Integrations from Functions
+
+When your app has an API integration registered in `manifest.yml`, call it from functions using FalconPy's `APIIntegrations` class. Do NOT make raw HTTP calls (urllib/requests) to the third-party API — always go through the Foundry platform proxy:
+
+```python
+from falconpy import APIIntegrations
+
+api = APIIntegrations()  # Zero-arg auth, same as other FalconPy classes
+
+# Call using definition_id + operation_id from your manifest
+response = api.execute_command_proxy(
+    body={
+        "resources": [
+            {
+                "definition_id": "ZscalerAPI",      # matches manifest api_integrations name
+                "operation_id": "urlLookup",        # matches OpenAPI spec operationId
+            }
+        ]
+    },
+)
+```
+
+For APIs that need a request body or query parameters:
+
+```python
+response = api.execute_command_proxy(
+    body={
+        "resources": [
+            {
+                "definition_id": "Anomali API",
+                "operation_id": "Intelligence",
+                "request": {
+                    "params": {
+                        "query": {"type": "ip", "value": ip_address}
+                    }
+                },
+            }
+        ]
+    },
+)
+```
+
+**Why the proxy?** The platform manages OAuth tokens, rate limiting, and audit logging for registered integrations. Raw HTTP calls bypass all of this and won't work in production because the function has no direct network access to external APIs — only the platform proxy can reach them.
+
+**Local testing note:** Use `definition_id` (the UUID from `manifest.yml`), not the human-readable integration name. After deploying once, the platform assigns UUIDs that appear in the manifest.
+
+Reference implementations:
+- [foundry-sample-zscaler-internet-access](https://github.com/CrowdStrike/foundry-sample-zscaler-internet-access) (6 functions using `execute_command_proxy`)
+- [foundry-sample-anomali-threatstream](https://github.com/CrowdStrike/foundry-sample-anomali-threatstream) (IOC ingestion via API integration)
+- [foundry-sample-openrouter-toolkit](https://github.com/CrowdStrike/foundry-sample-openrouter-toolkit) (`execute_command` variant)
+
 ### requirements.txt Best Practices
 
 Pin all dependencies to exact versions (`==`) for reproducible builds and supply chain safety. The one exception is `crowdstrike-falconpy`, which should be left unpinned so functions always pick up the latest SDK (needed for context-based auth and new service classes). Ensure the file ends with a trailing newline.
@@ -240,7 +291,8 @@ For the full `FunctionError` class with enum codes, see [references/python-patte
 - **`SearchObjects` returns metadata, not objects.** Follow up with `GetObject` to retrieve actual content.
 - **Returning arrays directly to workflows.** Wrap in a JSON object (`{'items': [...]}` not `[...]`).
 - **Using PATCH with Go functions.** Go only supports GET, POST, PUT, DELETE.
-- **Using `definition_id` vs. name for API integrations.** Calling API integrations from functions locally requires the UUID `definition_id` from `manifest.yml`, not the human-readable name.
+- **Using `definition_id` vs. name for API integrations.** Calling API integrations from functions requires the `definition_id` from `manifest.yml`, not the human-readable name. See the [Calling Registered API Integrations](#calling-registered-api-integrations-from-functions) section above.
+- **Making raw HTTP calls to third-party APIs.** When an API integration is registered in the manifest, MUST use `APIIntegrations().execute_command_proxy()` — raw urllib/requests calls bypass platform auth and won't reach external APIs in production.
 
 ## Use Cases
 

--- a/skills/workflows-development/SKILL.md
+++ b/skills/workflows-development/SKILL.md
@@ -225,7 +225,7 @@ Falcon Fusion SOAR uses [Common Expression Language (CEL)](https://github.com/go
 | `${data['action_key.API_Integration.Custom_Name.operationId.body']}` | Response body from an API integration action |
 | `${data['action_key.API_Integration.Custom_Name.operationId.body']}[0].field` | Access a field in the first element of an array response |
 | `${data['action_key.output.field']}` | Field from a platform action's output |
-| `${data['trigger.param_name']}` | On-demand trigger parameter value |
+| `${data['param_name']}` | On-demand trigger parameter value (use the parameter name directly, no prefix) |
 
 **CRITICAL:** Do NOT use `$action_name.output.body` — this passes as a literal string and is NOT resolved at runtime. Always use `${data['...']}` expressions.
 


### PR DESCRIPTION
Two improvements driven by eval LLM judge findings:

**1. Add `APIIntegrations.execute_command_proxy` pattern to functions skill**

Functions that call registered third-party API integrations should use FalconPy's `APIIntegrations` class rather than raw HTTP calls. This pattern was missing, causing generated apps to bypass registered integrations with raw urllib calls.

Added to `skills/functions-development/SKILL.md`:
- Full code examples for `execute_command_proxy` with `definition_id` + `operation_id`
- Request body/params pattern for APIs needing query parameters
- Explanation of why the platform proxy is required (auth, rate limiting, network access)
- References to 3 sample repos demonstrating the pattern
- New pitfall warning against raw HTTP calls when an integration is registered

Validated against 7 Python functions across foundry-sample-zscaler (4), anomali-threatstream, openrouter-toolkit, servicenow-idp, and servicenow-itsm.

**2. Fix incorrect trigger parameter variable syntax in workflows skill**

The skill documented `${data['trigger.param_name']}` but the correct syntax is `${data['param_name']}` (no prefix). Validated against:
- foundry-sample-foundryjs-demo: `${data['user_name']}`
- security-skills: 20+ workflows using direct param names
- No sample or library anywhere uses the `trigger.` prefix