### PR TITLE
Improve skill accuracy for Sonnet eval scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- **functions-development** — Added `APIIntegrations().execute_command_proxy()` code examples showing how to call registered third-party API integrations from function code. Includes request body/params patterns, explanation of why the platform proxy is required, and references to 3 sample repos. Added pitfall warning against making raw HTTP calls when an integration is registered.
+
 ## [1.2.0] - 2026-06-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
-- **functions-development** — Added `APIIntegrations().execute_command_proxy()` code examples showing how to call registered third-party API integrations from function code. Includes request body/params patterns, explanation of why the platform proxy is required, and references to 3 sample repos. Added pitfall warning against making raw HTTP calls when an integration is registered.
+- **workflows-development** — Added Response Action Workflow (Contain Host) example showing platform action discovery and usage. Added Contain device action ID to platform actions table.
+- **workflows-development** — Added null-guard warning near trigger parameters explaining they're prompted in the UI but may be empty via API or sub-workflow calls.
+- **functions-development** — Added credential management section with decision table (API integration vs FalconPy vs env vars) and callout that raw HTTP works but credentials are unencrypted and visible in app exports.
+- **functions-falcon-api** — Added OAuth scope reference table mapping FalconPy classes and methods to required manifest scopes, derived from all production sample apps. Notes that built-in capabilities don't need explicit scopes.
+- **api-integrations** — Added context paragraph explaining API integrations ARE Foundry's credential management system.
+- **ui-development** — Added async `connect()` callout explaining `falcon.connect()` must be in `useEffect` and navigation must be accessed after connect resolves via `useMemo` with `falcon.isConnected`.
 
 ### Fixed
 
+- **functions-development** — Corrected `definition_id` vs name guidance: name works in production, UUID only needed for local testing. Fixed raw HTTP claim from "won't work" to "works but credentials are unencrypted."
+- **functions-development** — Added `APIIntegrations().execute_command_proxy()` code examples showing how to call registered third-party API integrations from function code. Includes request body/params patterns, explanation of why the platform proxy is required, and references to 3 sample repos. Added pitfall warning against making raw HTTP calls when an integration is registered.
 - **workflows-development** — Fixed incorrect trigger parameter variable syntax. Was `${data['trigger.param_name']}`, corrected to `${data['param_name']}` (no prefix). Validated against foundry-sample-foundryjs-demo, security-skills (20+ workflows), and all other sample repos that consistently use direct parameter names.
 
 ## [1.2.0] - 2026-06-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 - **functions-development** — Added `APIIntegrations().execute_command_proxy()` code examples showing how to call registered third-party API integrations from function code. Includes request body/params patterns, explanation of why the platform proxy is required, and references to 3 sample repos. Added pitfall warning against making raw HTTP calls when an integration is registered.
 
+### Fixed
+
+- **workflows-development** — Fixed incorrect trigger parameter variable syntax. Was `${data['trigger.param_name']}`, corrected to `${data['param_name']}` (no prefix). Validated against foundry-sample-foundryjs-demo, security-skills (20+ workflows), and all other sample repos that consistently use direct parameter names.
+
 ## [1.2.0] - 2026-06-03
 
 ### Added

--- a/skills/api-integrations/SKILL.md
+++ b/skills/api-integrations/SKILL.md
@@ -23,6 +23,8 @@ metadata:
 
 This skill covers exposing external APIs (third-party services or CrowdStrike Falcon APIs) to the Falcon Foundry platform via OpenAPI/Swagger specifications. These integrations make API operations available to Falcon Fusion SOAR workflows, Foundry UI extensions, Foundry Functions, and other Foundry capabilities.
 
+**API integrations are how Foundry manages credentials.** There is no secrets system, no encrypted env vars, and no key vault. When you register an API integration, the platform collects credentials at install time and manages tokens automatically. This is why functions MUST call third-party REST APIs through `APIIntegrations().execute_command_proxy()` — not via raw HTTP with env vars.
+
 For calling Falcon APIs from within Function code, see **functions-falcon-api** instead.
 
 ## Decision Tree

--- a/skills/functions-development/SKILL.md
+++ b/skills/functions-development/SKILL.md
@@ -250,7 +250,7 @@ response = api.execute_command_proxy(
 
 **Why the proxy?** The platform manages OAuth tokens, rate limiting, and audit logging for registered integrations. Raw HTTP calls bypass all of this — while they can work with hardcoded or env-var credentials, those values are stored unencrypted and visible to anyone who exports the app.
 
-**Local testing note:** When testing locally, use the UUID `definition_id` assigned after first deploy (visible in `manifest.yml`). In production, the human-readable integration name (e.g., `"ZscalerAPI"`) works as the `definition_id` value.
+**Local testing note:** When testing locally, you may need the UUID `definition_id` from `manifest.yml` (assigned by the platform). In production, the human-readable integration name (e.g., `"ZscalerAPI"`) works as the `definition_id` value.
 
 Reference implementations:
 - [foundry-sample-zscaler-internet-access](https://github.com/CrowdStrike/foundry-sample-zscaler-internet-access) (6 functions using `execute_command_proxy`)

--- a/skills/functions-development/SKILL.md
+++ b/skills/functions-development/SKILL.md
@@ -45,7 +45,7 @@ Before writing a function, exhaust alternatives — each one avoids deployment c
 | CrowdStrike Falcon API | FalconPy zero-arg constructor (`Alerts()`, `Hosts()`) | Platform-managed automatically |
 | Third-party GraphQL API (no OpenAPI spec) | Function with `requests` + env var | Visible in app exports (⚠️ security risk) |
 
-**CRITICAL:** If the API has a REST endpoint and an OpenAPI spec exists, you MUST use an API integration. NEVER use `os.environ` with API keys, `requests.get()` with hardcoded URLs, or localStorage for credentials when an API integration can handle it. The platform manages OAuth tokens, and functions have no direct network access to external APIs in production — only the platform proxy can reach them.
+**CRITICAL:** If the API has a REST endpoint and an OpenAPI spec exists, you MUST use an API integration. NEVER use `os.environ` with API keys, `requests.get()` with hardcoded URLs, or localStorage for credentials when an API integration can handle it. Raw HTTP with env vars technically works, but credentials are unencrypted and visible in app exports.
 
 ## Reference Files
 
@@ -248,7 +248,7 @@ response = api.execute_command_proxy(
 )
 ```
 
-**Why the proxy?** The platform manages OAuth tokens, rate limiting, and audit logging for registered integrations. Raw HTTP calls bypass all of this and won't work in production because the function has no direct network access to external APIs — only the platform proxy can reach them.
+**Why the proxy?** The platform manages OAuth tokens, rate limiting, and audit logging for registered integrations. Raw HTTP calls bypass all of this — while they can work with hardcoded or env-var credentials, those values are stored unencrypted and visible to anyone who exports the app.
 
 **Local testing note:** When testing locally, use the UUID `definition_id` assigned after first deploy (visible in `manifest.yml`). In production, the human-readable integration name (e.g., `"ZscalerAPI"`) works as the `definition_id` value.
 
@@ -304,7 +304,7 @@ For the full `FunctionError` class with enum codes, see [references/python-patte
 - **Returning arrays directly to workflows.** Wrap in a JSON object (`{'items': [...]}` not `[...]`).
 - **Using PATCH with Go functions.** Go only supports GET, POST, PUT, DELETE.
 - **Using `definition_id` vs. name for API integrations.** When testing locally, use the UUID `definition_id` from `manifest.yml`. In production, the human-readable name (e.g., `"ZscalerAPI"`) works as the `definition_id` value. See the [Calling Registered API Integrations](#calling-registered-api-integrations-from-functions) section above.
-- **Making raw HTTP calls to third-party APIs.** When an API integration is registered in the manifest, MUST use `APIIntegrations().execute_command_proxy()` — raw urllib/requests calls bypass platform auth and won't reach external APIs in production.
+- **Making raw HTTP calls to third-party APIs.** When an API integration is registered in the manifest, MUST use `APIIntegrations().execute_command_proxy()`. Raw urllib/requests calls can technically work with hardcoded credentials or env vars, but credentials are stored unencrypted and visible in app exports — a security risk. Always prefer the API integration path.
 
 ## Use Cases
 

--- a/skills/functions-development/SKILL.md
+++ b/skills/functions-development/SKILL.md
@@ -35,6 +35,18 @@ Before writing a function, exhaust alternatives — each one avoids deployment c
 - **API Integrations** (HTTP Actions) for calling external APIs directly from workflows
 - **UI Extensions** with `foundry-js` for client-side data fetching
 
+## Credential Management — No Secrets System Exists
+
+**There is no secrets management in Falcon Foundry.** When calling third-party REST APIs:
+
+| Scenario | Approach | Credentials |
+|----------|----------|-------------|
+| Third-party REST API (VirusTotal, Slack, Jira, etc.) | API integration in manifest + `APIIntegrations().execute_command_proxy()` | Platform-managed at install time |
+| CrowdStrike Falcon API | FalconPy zero-arg constructor (`Alerts()`, `Hosts()`) | Platform-managed automatically |
+| Third-party GraphQL API (no OpenAPI spec) | Function with `requests` + env var | Visible in app exports (⚠️ security risk) |
+
+**CRITICAL:** If the API has a REST endpoint and an OpenAPI spec exists, you MUST use an API integration. NEVER use `os.environ` with API keys, `requests.get()` with hardcoded URLs, or localStorage for credentials when an API integration can handle it. The platform manages OAuth tokens, and functions have no direct network access to external APIs in production — only the platform proxy can reach them.
+
 ## Reference Files
 
 This skill is split across multiple files. Consult these for full examples:

--- a/skills/functions-development/SKILL.md
+++ b/skills/functions-development/SKILL.md
@@ -194,6 +194,57 @@ falcon = Alerts()  # Auth is automatic — do not pass credentials
 
 FalconPy already reads env vars internally, so writing a `get_falcon_client()` wrapper that manually reads credentials adds no value and breaks context auth in the cloud.
 
+### Calling Registered API Integrations from Functions
+
+When your app has an API integration registered in `manifest.yml`, call it from functions using FalconPy's `APIIntegrations` class. Do NOT make raw HTTP calls (urllib/requests) to the third-party API — always go through the Foundry platform proxy:
+
+```python
+from falconpy import APIIntegrations
+
+api = APIIntegrations()  # Zero-arg auth, same as other FalconPy classes
+
+# Call using definition_id + operation_id from your manifest
+response = api.execute_command_proxy(
+    body={
+        "resources": [
+            {
+                "definition_id": "ZscalerAPI",      # matches manifest api_integrations name
+                "operation_id": "urlLookup",        # matches OpenAPI spec operationId
+            }
+        ]
+    },
+)
+```
+
+For APIs that need a request body or query parameters:
+
+```python
+response = api.execute_command_proxy(
+    body={
+        "resources": [
+            {
+                "definition_id": "Anomali API",
+                "operation_id": "Intelligence",
+                "request": {
+                    "params": {
+                        "query": {"type": "ip", "value": ip_address}
+                    }
+                },
+            }
+        ]
+    },
+)
+```
+
+**Why the proxy?** The platform manages OAuth tokens, rate limiting, and audit logging for registered integrations. Raw HTTP calls bypass all of this and won't work in production because the function has no direct network access to external APIs — only the platform proxy can reach them.
+
+**Local testing note:** Use `definition_id` (the UUID from `manifest.yml`), not the human-readable integration name. After deploying once, the platform assigns UUIDs that appear in the manifest.
+
+Reference implementations:
+- [foundry-sample-zscaler-internet-access](https://github.com/CrowdStrike/foundry-sample-zscaler-internet-access) (6 functions using `execute_command_proxy`)
+- [foundry-sample-anomali-threatstream](https://github.com/CrowdStrike/foundry-sample-anomali-threatstream) (IOC ingestion via API integration)
+- [foundry-sample-openrouter-toolkit](https://github.com/CrowdStrike/foundry-sample-openrouter-toolkit) (`execute_command` variant)
+
 ### requirements.txt Best Practices
 
 Pin all dependencies to exact versions (`==`) for reproducible builds and supply chain safety. The one exception is `crowdstrike-falconpy`, which should be left unpinned so functions always pick up the latest SDK (needed for context-based auth and new service classes). Ensure the file ends with a trailing newline.
@@ -240,7 +291,8 @@ For the full `FunctionError` class with enum codes, see [references/python-patte
 - **`SearchObjects` returns metadata, not objects.** Follow up with `GetObject` to retrieve actual content.
 - **Returning arrays directly to workflows.** Wrap in a JSON object (`{'items': [...]}` not `[...]`).
 - **Using PATCH with Go functions.** Go only supports GET, POST, PUT, DELETE.
-- **Using `definition_id` vs. name for API integrations.** Calling API integrations from functions locally requires the UUID `definition_id` from `manifest.yml`, not the human-readable name.
+- **Using `definition_id` vs. name for API integrations.** Calling API integrations from functions requires the `definition_id` from `manifest.yml`, not the human-readable name. See the [Calling Registered API Integrations](#calling-registered-api-integrations-from-functions) section above.
+- **Making raw HTTP calls to third-party APIs.** When an API integration is registered in the manifest, MUST use `APIIntegrations().execute_command_proxy()` — raw urllib/requests calls bypass platform auth and won't reach external APIs in production.
 
 ## Use Cases
 

--- a/skills/functions-development/SKILL.md
+++ b/skills/functions-development/SKILL.md
@@ -250,7 +250,7 @@ response = api.execute_command_proxy(
 
 **Why the proxy?** The platform manages OAuth tokens, rate limiting, and audit logging for registered integrations. Raw HTTP calls bypass all of this and won't work in production because the function has no direct network access to external APIs — only the platform proxy can reach them.
 
-**Local testing note:** Use `definition_id` (the UUID from `manifest.yml`), not the human-readable integration name. After deploying once, the platform assigns UUIDs that appear in the manifest.
+**Local testing note:** When testing locally, use the UUID `definition_id` assigned after first deploy (visible in `manifest.yml`). In production, the human-readable integration name (e.g., `"ZscalerAPI"`) works as the `definition_id` value.
 
 Reference implementations:
 - [foundry-sample-zscaler-internet-access](https://github.com/CrowdStrike/foundry-sample-zscaler-internet-access) (6 functions using `execute_command_proxy`)
@@ -303,7 +303,7 @@ For the full `FunctionError` class with enum codes, see [references/python-patte
 - **`SearchObjects` returns metadata, not objects.** Follow up with `GetObject` to retrieve actual content.
 - **Returning arrays directly to workflows.** Wrap in a JSON object (`{'items': [...]}` not `[...]`).
 - **Using PATCH with Go functions.** Go only supports GET, POST, PUT, DELETE.
-- **Using `definition_id` vs. name for API integrations.** Calling API integrations from functions requires the `definition_id` from `manifest.yml`, not the human-readable name. See the [Calling Registered API Integrations](#calling-registered-api-integrations-from-functions) section above.
+- **Using `definition_id` vs. name for API integrations.** When testing locally, use the UUID `definition_id` from `manifest.yml`. In production, the human-readable name (e.g., `"ZscalerAPI"`) works as the `definition_id` value. See the [Calling Registered API Integrations](#calling-registered-api-integrations-from-functions) section above.
 - **Making raw HTTP calls to third-party APIs.** When an API integration is registered in the manifest, MUST use `APIIntegrations().execute_command_proxy()` — raw urllib/requests calls bypass platform auth and won't reach external APIs in production.
 
 ## Use Cases

--- a/skills/functions-falcon-api/SKILL.md
+++ b/skills/functions-falcon-api/SKILL.md
@@ -289,6 +289,8 @@ Every FalconPy service class call requires the correct OAuth scope(s) declared i
 | `FirewallManagement` | `create_rule_group`, `query_events`, `get_events` | `firewall-management:read`, `firewall-management:write` | foundry-sample-category-blocking |
 | `HostGroup` | `query_host_groups`, `get_host_groups` | `host-group:read`, `host-group:write` | foundry-sample-category-blocking |
 
+**Go functions (gofalcon) require the same scopes.** The table above uses FalconPy class/method names, but the underlying Falcon API scopes are identical regardless of SDK. If your Go function calls the RTR admin API, declare `real-time-response-admin:write`. If it manages incidents, declare `incidents:read`, `incidents:write`.
+
 ### How to declare scopes
 
 ```yaml

--- a/skills/functions-falcon-api/SKILL.md
+++ b/skills/functions-falcon-api/SKILL.md
@@ -286,10 +286,8 @@ Every FalconPy service class call requires the correct OAuth scope(s) declared i
 | `IdentityProtection` | (policy rules) | `identity-policy-rules:read`, `identity-policy-rules:write` | foundry-sample-servicenow-idp |
 | `NGSIEM` | `upload_file` | `humio-auth-proxy:write` | foundry-sample-ngsiem-importer |
 | `FoundryLogScale` | `ingest_data` | `app-logs:read`, `app-logs:write` | foundry-sample-logscale |
-| `FirewallManagement` | (rule/policy management) | `firewall-management:read`, `firewall-management:write` | foundry-sample-category-blocking |
-| `HostGroup` | (group operations) | `host-group:read`, `host-group:write` | foundry-sample-category-blocking |
-| (RTR admin) | (session commands) | `real-time-response-admin:write` | foundry-sample-rapid-response |
-| `Incidents` | (incident management) | `incidents:read`, `incidents:write` | foundry-sample-charlotte-toolkit |
+| `FirewallManagement` | `create_rule_group`, `query_events`, `get_events` | `firewall-management:read`, `firewall-management:write` | foundry-sample-category-blocking |
+| `HostGroup` | `query_host_groups`, `get_host_groups` | `host-group:read`, `host-group:write` | foundry-sample-category-blocking |
 
 ### How to declare scopes
 

--- a/skills/functions-falcon-api/SKILL.md
+++ b/skills/functions-falcon-api/SKILL.md
@@ -273,17 +273,14 @@ Every FalconPy service class call requires the correct OAuth scope(s) declared i
 
 ### Scope Reference (verified from production sample apps)
 
+Each row maps a FalconPy method actually called in a sample function to the scope declared in that app's manifest.
+
 | FalconPy Class | Methods | Required Scope(s) | Verified In |
 |---|---|---|---|
-| `Hosts` | `query_devices_by_filter`, `get_device_details` | `devices:read` | foundry-sample-functions-python |
-| `Hosts` | `perform_action` (contain/lift containment) | `devices:read`, `devices:write` | foundry-sample-rapid-response |
-| `IOC` | `indicator_create_v1` | `iocs:write` | foundry-sample-zscaler-internet-access |
+| `Hosts` | `get_device_details` | `devices:read` | foundry-sample-functions-python |
 | `Intel` | `query_indicator_ids` | `falconx-indicators:read` | foundry-sample-zscaler-internet-access |
-| `Alerts` | `get_queries_alerts_v2`, `get_alerts_v2` | `alerts:read` | foundry-sample-mitre |
-| `Detects` | `query_detects`, `get_detect_summaries` | `detects:read` | foundry-sample-mitre |
-| `IdentityProtection` | `graphql()` | `identity-graphql:write` | foundry-sample-idp-notifications |
-| `IdentityProtection` | `query_sensors`, `get_sensor_details` | `identity-entities:read` | foundry-sample-idp-notifications |
-| `IdentityProtection` | (policy rules) | `identity-policy-rules:read`, `identity-policy-rules:write` | foundry-sample-servicenow-idp |
+| `IdentityProtection` | `graphql`, `query_sensors`, `get_sensor_details` | `identity-graphql:write`, `identity-entities:read` | foundry-sample-idp-notifications |
+| `IdentityProtection` | `query_policy_rules`, `get_policy_rules`, `delete_policy_rules` | `identity-policy-rules:read`, `identity-policy-rules:write` | foundry-sample-servicenow-idp |
 | `NGSIEM` | `upload_file` | `humio-auth-proxy:write` | foundry-sample-ngsiem-importer |
 | `FoundryLogScale` | `ingest_data` | `app-logs:read`, `app-logs:write` | foundry-sample-logscale |
 | `FirewallManagement` | `create_rule_group`, `query_events`, `get_events` | `firewall-management:read`, `firewall-management:write` | foundry-sample-category-blocking |
@@ -298,7 +295,7 @@ Every FalconPy service class call requires the correct OAuth scope(s) declared i
 auth:
     scopes:
         - devices:read
-        - iocs:write
+        - falconx-indicators:read
     permissions: {}
     roles: []
 ```

--- a/skills/functions-falcon-api/SKILL.md
+++ b/skills/functions-falcon-api/SKILL.md
@@ -263,6 +263,53 @@ curl -X GET http://localhost:8081/api/alerts?limit=10
 
 The zero-arg pattern works seamlessly in both local and cloud environments.
 
+## OAuth Scopes for manifest.yml
+
+Every FalconPy service class call requires the correct OAuth scope(s) declared in your manifest's `auth.scopes` array. Without the right scopes, the function gets a 403 at runtime. `foundry apps validate` does NOT catch missing scopes — it only fails at runtime.
+
+> **⚠️ Scope names don't always match class names.** The `Hosts` class requires `devices:read`, not `hosts:read`. Always use this table rather than guessing from class names.
+
+> **Built-in capabilities don't need scopes.** API integrations, collections, workflows, and LogScale ingestion work without declaring their scopes when used through Foundry's built-in SDK patterns (`falcon.apiIntegration()`, `CustomStorage()` for app collections, etc.). Only declare scopes when calling Falcon platform APIs directly via FalconPy service classes.
+
+### Scope Reference (verified from production sample apps)
+
+| FalconPy Class | Methods | Required Scope(s) | Verified In |
+|---|---|---|---|
+| `Hosts` | `query_devices_by_filter`, `get_device_details` | `devices:read` | foundry-sample-functions-python |
+| `Hosts` | `perform_action` (contain/lift containment) | `devices:read`, `devices:write` | foundry-sample-rapid-response |
+| `IOC` | `indicator_create_v1` | `iocs:write` | foundry-sample-zscaler-internet-access |
+| `Intel` | `query_indicator_ids` | `falconx-indicators:read` | foundry-sample-zscaler-internet-access |
+| `Alerts` | `get_queries_alerts_v2`, `get_alerts_v2` | `alerts:read` | foundry-sample-mitre |
+| `Detects` | `query_detects`, `get_detect_summaries` | `detects:read` | foundry-sample-mitre |
+| `IdentityProtection` | `graphql()` | `identity-graphql:write` | foundry-sample-idp-notifications |
+| `IdentityProtection` | `query_sensors`, `get_sensor_details` | `identity-entities:read` | foundry-sample-idp-notifications |
+| `IdentityProtection` | (policy rules) | `identity-policy-rules:read`, `identity-policy-rules:write` | foundry-sample-servicenow-idp |
+| `NGSIEM` | `upload_file` | `humio-auth-proxy:write` | foundry-sample-ngsiem-importer |
+| `FoundryLogScale` | `ingest_data` | `app-logs:read`, `app-logs:write` | foundry-sample-logscale |
+| `FirewallManagement` | (rule/policy management) | `firewall-management:read`, `firewall-management:write` | foundry-sample-category-blocking |
+| `HostGroup` | (group operations) | `host-group:read`, `host-group:write` | foundry-sample-category-blocking |
+| (RTR admin) | (session commands) | `real-time-response-admin:write` | foundry-sample-rapid-response |
+| `Incidents` | (incident management) | `incidents:read`, `incidents:write` | foundry-sample-charlotte-toolkit |
+
+### How to declare scopes
+
+```yaml
+# manifest.yml
+auth:
+    scopes:
+        - devices:read
+        - iocs:write
+    permissions: {}
+    roles: []
+```
+
+### When unsure about the correct scope
+
+If you're using a FalconPy method not in this table:
+1. Check the method's HTTP verb and API path in FalconPy source — GET typically needs `:read`, POST/PUT/PATCH/DELETE typically needs `:write`
+2. The scope prefix is usually the **API path prefix** (e.g., `/iocs/...` → `iocs`, `/devices/...` → `devices`), but exceptions exist (`Hosts` → `devices`, `NGSIEM` → `humio-auth-proxy`)
+3. When ambiguous, **ask the user** which scopes to include rather than guessing
+
 ## Common Pitfalls
 
 - **Writing OAuth code or credential management.** Auth is completely automatic inside FDK handlers.

--- a/skills/ui-development/SKILL.md
+++ b/skills/ui-development/SKILL.md
@@ -137,6 +137,16 @@ const theme = await falcon.theme();
 document.documentElement.classList.add(`sl-theme-${theme}`);
 ```
 
+> **⚠️ `connect()` is async.** In React, `falcon.connect()` must be called inside a `useEffect` and navigation/theme must only be accessed AFTER connect resolves. Use `falcon.isConnected` as a dependency for `useMemo`:
+>
+> ```jsx
+> const navigation = useMemo(() => {
+>   return falcon.isConnected ? falcon.navigation : undefined;
+> }, [falcon.isConnected]);
+> ```
+>
+> Gate child rendering on `isInitialized` state. See [references/react-patterns.md](references/react-patterns.md) for the full `FalconApiProvider` pattern.
+
 ### Calling API Integrations
 
 Use `falcon.apiIntegration()` for third-party APIs. Use `falcon.api.get()` for CrowdStrike Falcon APIs.

--- a/skills/workflows-development/SKILL.md
+++ b/skills/workflows-development/SKILL.md
@@ -89,6 +89,22 @@ output_fields: []
 | On demand | `name: On demand`, `type: On demand` |
 | Scheduled | `event: Schedule`, `schedule: {time_cycle: "0 */6 * * *", tz: Etc/UTC}` |
 
+> **⚠️ Null-guard trigger parameters:** On-demand trigger parameters are optional — they may be null or empty at runtime. Always guard before using them:
+>
+> ```yaml
+> conditions:
+>     check_param:
+>         cel_expression: "data['param_name'] != null && data['param_name'] != ''"
+>         next:
+>             - use_param
+>         display:
+>             - param_name was provided
+>         else:
+>             - handle_missing
+> ```
+>
+> Or inline in CEL: `${data['param'] != null ? data['param'] : "default"}`
+
 **Variable syntax in actions:** Use `${data['action_key.path.to.field']}` CEL expressions. See [Variable References](#variable-references) for the full syntax. Do NOT use `$action_name.output.body` — it passes as a literal string and is not resolved.
 
 **Version constraints:** Every action requires `version_constraint`. Use `~0` for function actions and API integration actions. Use `~1` for platform actions (Print data, Send email, Create/Update variable, etc.):
@@ -179,6 +195,7 @@ Platform actions (send email, log output, create detection) require platform-spe
 | Send email | `07413ef9ba7c47bf5a242799f59902cc` |
 | Request human input - Send email | `d6731c10b24834e2e0f4bd9d390a29c8` |
 | Get device details | `6265dc947cc2252f74a5f25261ac36a9` |
+| Contain device | `bec9fbeb4999d207937854fd56088107` |
 
 For actions not in this table, use `foundry workflows actions view --name "..."` or the API query in [references/action-discovery.md](references/action-discovery.md). There are 9,000+ platform actions available. MUST NOT guess action IDs — use discovery commands.
 

--- a/skills/workflows-development/SKILL.md
+++ b/skills/workflows-development/SKILL.md
@@ -89,7 +89,7 @@ output_fields: []
 | On demand | `name: On demand`, `type: On demand` |
 | Scheduled | `event: Schedule`, `schedule: {time_cycle: "0 */6 * * *", tz: Etc/UTC}` |
 
-> **⚠️ Null-guard trigger parameters:** On-demand trigger parameters are optional — they may be null or empty at runtime. Always guard before using them:
+> **⚠️ Null-guard trigger parameters:** When run from the Falcon console, the UI prompts users to fill in parameters. However, when triggered via API or from another workflow, parameters may be empty. Guard defensively:
 >
 > ```yaml
 > conditions:

--- a/skills/workflows-development/SKILL.md
+++ b/skills/workflows-development/SKILL.md
@@ -107,19 +107,29 @@ output_fields: []
 
 **Variable syntax in actions:** Use `${data['action_key.path.to.field']}` CEL expressions. See [Variable References](#variable-references) for the full syntax. Do NOT use `$action_name.output.body` — it passes as a literal string and is not resolved.
 
-**Version constraints:** Every action requires `version_constraint`. Use `~0` for function actions and API integration actions. Use `~1` for platform actions (Print data, Send email, Create/Update variable, etc.):
+**Version constraints:** Every action requires `version_constraint`. The `~N` value pins against the activity's declared `semantic_version` field, not its internal iteration count. The rule:
+
+- `~0` = activity has **no** `semantic_version` defined (functions, API integrations, and some platform actions like "contain device")
+- `~1` = activity **has** a `semantic_version` (most platform actions: Print data, Send email, Create/Update variable, Get device details, etc.)
+
+Use `foundry workflows actions view --name "<action>"` to check. If the activity output shows a semantic_version field, use `~1`. If it does not, use `~0`.
 
 ```yaml
 actions:
     my_function:
         id: functions.my-func.process
         properties: {}
-        version_constraint: ~0       # ~0 for functions
+        version_constraint: ~0       # no semantic_version defined
+    contain_host:
+        id: <contain-device-action-id>
+        properties:
+            device_id: "${data['trigger.device_id']}"
+        version_constraint: ~0       # no semantic_version defined
     print_results:
         id: aadbf530e35fc452a032f5f8acaaac2a
         properties:
             text_data: "${data['my_function.output']}"
-        version_constraint: ~1       # ~1 for platform actions
+        version_constraint: ~1       # has semantic_version
 ```
 
 ### Manifest Configuration

--- a/skills/workflows-development/SKILL.md
+++ b/skills/workflows-development/SKILL.md
@@ -225,7 +225,7 @@ Falcon Fusion SOAR uses [Common Expression Language (CEL)](https://github.com/go
 | `${data['action_key.API_Integration.Custom_Name.operationId.body']}` | Response body from an API integration action |
 | `${data['action_key.API_Integration.Custom_Name.operationId.body']}[0].field` | Access a field in the first element of an array response |
 | `${data['action_key.output.field']}` | Field from a platform action's output |
-| `${data['trigger.param_name']}` | On-demand trigger parameter value |
+| `${data['param_name']}` | On-demand trigger parameter value (use the parameter name directly, no prefix) |
 
 **CRITICAL:** Do NOT use `$action_name.output.body` — this passes as a literal string and is NOT resolved at runtime. Always use `${data['...']}` expressions.
 

--- a/skills/workflows-development/references/workflow-examples.md
+++ b/skills/workflows-development/references/workflow-examples.md
@@ -91,6 +91,75 @@ output_fields: []
 - `${data['action_key.API_Integration.Custom_Name.operationId.body']}` to access API response body via CEL expression
 - `output_fields: []` when no fields need to be surfaced
 
+## Response Action Workflow (Contain Host)
+
+Platform response actions (contain device, lift containment, create IOC) use discovered action IDs. To find the ID, run:
+
+```bash
+foundry workflows actions view --name "contain"
+```
+
+This example demonstrates an on-demand workflow that contains a host by device ID, with a null-guard condition to prevent runtime errors when the parameter is empty.
+
+```yaml
+name: Contain Malicious Host
+description: On-demand workflow to network-contain a host by device ID
+provision_on_install: true
+trigger:
+    next:
+        - check_device_id
+    name: On demand
+    parameters:
+        properties:
+            device_id:
+                type: string
+        type: object
+    type: On demand
+actions:
+    check_device_id:
+        next:
+            - contain_host
+        id: 702d15788dbbffdf0b68d8e2f3599aa4
+        class: CreateVariable
+        properties:
+            variable_schema:
+                properties:
+                    status:
+                        type: string
+                type: object
+        version_constraint: ~1
+    contain_host:
+        id: bec9fbeb4999d207937854fd56088107
+        next:
+            - print_result
+        properties:
+            device_id: "${data['device_id']}"
+        version_constraint: ~1
+    print_result:
+        id: aadbf530e35fc452a032f5f8acaaac2a
+        properties:
+            text_data: "Containment initiated for device ${data['device_id']}"
+        version_constraint: ~1
+conditions:
+    check_device_id:
+        cel_expression: "data['device_id'] != null && data['device_id'] != ''"
+        next:
+            - contain_host
+        display:
+            - device_id was provided
+        else:
+            - print_result
+```
+
+**Patterns demonstrated:**
+- Discovering platform actions via `foundry workflows actions view --name "..."`
+- `conditions:` with `cel_expression:` for null-guarding trigger parameters
+- `else:` routing to a fallback action when the parameter is missing
+- Response action pattern with a real platform action ID (`bec9fbeb4999d207937854fd56088107` = Contain device)
+- CEL null-guard: `data['field'] != null && data['field'] != ''`
+
+> **⚠️ Always discover action IDs** — do NOT guess or hardcode IDs from this example for other actions. Use `foundry workflows actions view --name "..."` or the API query in [action-discovery.md](action-discovery.md) to find the correct ID for your specific use case.
+
 ## Scheduled Workflow with Pagination Loop
 
 From [foundry-sample-anomali-threatstream](https://github.com/CrowdStrike/foundry-sample-anomali-threatstream). Scheduled trigger with loop-based pagination using a custom variable to track the cursor.

--- a/skills/workflows-development/references/workflow-examples.md
+++ b/skills/workflows-development/references/workflow-examples.md
@@ -107,7 +107,7 @@ description: On-demand workflow to network-contain a host by device ID
 provision_on_install: true
 trigger:
     next:
-        - check_device_id
+        - validate_device_id
     name: On demand
     parameters:
         properties:
@@ -116,18 +116,6 @@ trigger:
         type: object
     type: On demand
 actions:
-    check_device_id:
-        next:
-            - contain_host
-        id: 702d15788dbbffdf0b68d8e2f3599aa4
-        class: CreateVariable
-        properties:
-            variable_schema:
-                properties:
-                    status:
-                        type: string
-                type: object
-        version_constraint: ~1
     contain_host:
         id: bec9fbeb4999d207937854fd56088107
         next:
@@ -141,7 +129,7 @@ actions:
             text_data: "Containment initiated for device ${data['device_id']}"
         version_constraint: ~1
 conditions:
-    check_device_id:
+    validate_device_id:
         cel_expression: "data['device_id'] != null && data['device_id'] != ''"
         next:
             - contain_host


### PR DESCRIPTION
Targeted improvements to address eval failures when running with claude-sonnet-4-6. Sonnet consistently generates wrong patterns in several areas. These additions provide stronger guardrails and accurate reference material without changing behavior for models that already get it right.

**Workflow improvements (workflows-development):**
- Add Response Action Workflow (Contain Host) example with platform action discovery
- Add Contain device action ID to the platform actions table
- Add null-guard warning near trigger parameters (prompted in UI, may be empty via API)

**Credential management (functions-development, api-integrations):**
- Add decision table clarifying when to use API integrations vs FalconPy vs env vars
- Clarify that raw HTTP with env vars works but credentials are unencrypted and visible in exports
- Add context paragraph to api-integrations explaining it IS the credential management system

**OAuth scopes (functions-falcon-api):**
- Add scope reference table derived from all production sample apps
- Maps FalconPy classes + methods to required manifest scopes
- Notes that built-in capabilities (API integrations, collections) don't need explicit scopes
- Guidance for ambiguous cases (ask the user)

**UI patterns (ui-development):**
- Add async connect() callout explaining navigation must be accessed after connect resolves

**Accuracy corrections (functions-development):**
- Fix definition_id vs name: name works in production, UUID only needed locally
- Correct raw HTTP claim: technically works but unencrypted, not "impossible"

**Eval impact (Sonnet, 5/5 passing):**
- abuseipdb-block-workflow: 3/5 → 4/5
- greynoise-detection-extension: FAIL → 4/5 PASS
- jira-detection-workflow: 3/5 → 4/5
- slack-alert-notifications: 4/5 → 4/5 (stable)
- virustotal-app: 4/5 → 4/5 (stable)

**Note:** These are Sonnet-targeted optimizations. Keeping as draft until validated that Opus performance does not regress.