### PR TITLE
Add HTTP Actions reference, fix CEL has() usage, add optional patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
+- **workflows-development** — Added HTTP Actions reference (`references/http-actions.md`) with verified `Inline.HTTPRequest` schema, both auth patterns (API key header and OAuth 2.0 client credentials), status-code conditional routing, and an HTTP-Actions-vs-API-integration decision guide. Added a callout so HTTP Actions are suggested for simple REST calls that don't need an app.
 - **ui-development** — Added Vanilla JS as a first-class template option for pages and extensions. Includes CLI scaffolding examples, note that no npm install/build step is needed, and clarification that vite/build-related pitfalls are React-specific.
 - **workflows-development** — Added Response Action Workflow (Contain Host) example showing platform action discovery and usage. Added Contain device action ID to platform actions table.
 - **workflows-development** — Added null-guard warning near trigger parameters explaining they're prompted in the UI but may be empty via API or sub-workflow calls.

--- a/skills/workflows-development/SKILL.md
+++ b/skills/workflows-development/SKILL.md
@@ -271,6 +271,7 @@ Falcon Fusion SOAR supports CEL for data transformations, conditions, and field 
 ```yaml
 # Check if results exist before accessing
 "${size(data['eventQuery.results']) > 0 ? data['eventQuery.results'][0].field : \"N/A\"}"
+# (len() is a null-safe alternative to size() — len(null) returns 0 instead of erroring)
 
 # Null-safe field access — traditional pattern
 "${data['action.field'] != null ? data['action.field'] : \"default\"}"
@@ -284,11 +285,11 @@ Falcon Fusion SOAR supports CEL for data transformations, conditions, and field 
 # Safe list exists-and-non-empty check
 "${len(data[?'Key'].orValue([])) > 0}"
 
-# Array element access
-"${data['action.API_Integration.Custom_Name.op.body']}[0]"
+# Array element access (index goes INSIDE the ${...}, not after it)
+"${data['action.API_Integration.Custom_Name.op.body'][0]}"
 
-# Lookup table (useful for mapping severity integers to strings)
-"${'1': 'Low', '2': 'Medium', '3': 'High', '4': 'Critical'}[string(data['severity'])]"
+# Lookup table (map literal needs its own braces inside ${...})
+"${ {'1': 'Low', '2': 'Medium', '3': 'High', '4': 'Critical'}[string(data['severity'])] }"
 ```
 
 **`has()` vs `!= null` — know the difference:**

--- a/skills/workflows-development/SKILL.md
+++ b/skills/workflows-development/SKILL.md
@@ -161,7 +161,7 @@ If a function was created without workflow integration and you later need it cal
 
 ## Calling API Integration Operations
 
-> **💡 Consider HTTP Actions first.** For a simple REST call that doesn't need a custom UI or reusable function, an HTTP Action is faster than building an API integration — no app, no OpenAPI spec, no deploy. Suggest it when the user just wants a workflow to hit an endpoint and use the response. See [references/http-actions.md](references/http-actions.md). Use a full API integration when the operation is reused across workflows or paired with functions/UI.
+> **💡 Consider HTTP Actions first.** For a simple REST call that doesn't need a custom UI or reusable function, an HTTP Action is faster than an API integration — no app, no OpenAPI spec, no deploy. Use a full API integration when the operation is reused across workflows or paired with functions/UI. See [references/http-actions.md](references/http-actions.md).
 
 Workflows invoke API integration operations using the `api_integrations.{name}.{operationId}` pattern:
 
@@ -266,40 +266,22 @@ The `action_key` is the YAML key of the action (e.g., `list_users` from `actions
 
 ### CEL Expressions
 
-Falcon Fusion SOAR supports CEL for data transformations, conditions, and field access. Key patterns:
+Falcon Fusion SOAR supports CEL for data transformations, conditions, and field access. Common patterns:
 
 ```yaml
-# Check if results exist before accessing
-"${size(data['eventQuery.results']) > 0 ? data['eventQuery.results'][0].field : \"N/A\"}"
-# (len() is a null-safe alternative to size() — len(null) returns 0 instead of erroring)
-
-# Null-safe field access — traditional pattern
-"${data['action.field'] != null ? data['action.field'] : \"default\"}"
-
-# Null-safe field access — optional pattern (preferred, avoids verbose null checks)
+# Null-safe field access — optional pattern (preferred)
 "${data[?'action.field'].orValue(\"default\")}"
 
-# Fallback chain (like ?? coalescing — tries each key, returns first that exists)
-"${data[?'primary'].or(data[?'fallback']).orValue(\"none\")}"
-
-# Safe list exists-and-non-empty check
-"${len(data[?'Key'].orValue([])) > 0}"
+# Traditional null check
+"${data['action.field'] != null ? data['action.field'] : \"default\"}"
 
 # Array element access (index goes INSIDE the ${...}, not after it)
 "${data['action.API_Integration.Custom_Name.op.body'][0]}"
-
-# Lookup table (map literal needs its own braces inside ${...})
-"${ {'1': 'Low', '2': 'Medium', '3': 'High', '4': 'Critical'}[string(data['severity'])] }"
 ```
 
-**`has()` vs `!= null` — know the difference:**
-- `data['key'] != null` — checks if a **data store key** has a value. Use for trigger parameters and action outputs.
-- `has(obj.field)` — checks if a **field exists on a retrieved object**. Only works *after* you've retrieved an object from the data store (e.g., `has(data['WorkflowCustomVariable'].offset)` works because CEL first retrieves `WorkflowCustomVariable` then checks `.offset`). Do NOT use `has(data['key'])` directly on the data store — this fails with `Q0910: invalid argument to has() macro`.
-- `data[?'key'].orValue(default)` — the cleanest approach. Uses CEL optionals to safely handle missing keys without verbose null checks.
+**`has()` only works on retrieved objects, not data store keys.** `has(data['key'])` fails with `Q0910`; use `data['key'] != null` for keys, or `has(data['var'].field)` to check a field on an already-retrieved object.
 
-CrowdStrike provides [custom CEL extensions](https://docs.crowdstrike.com/r/k223d842) including `cs.json.valid()`, `cs.json.decode()`, `cs.ip.valid()`, `cs.timestamp.now()`, and `cs.timestamp.parse()`. For complex transformations, the **Data Transformation Agent** (requires Charlotte AI) generates CEL expressions from plain language descriptions.
-
-For schemaless event queries and dynamic data handling patterns, see [Falcon Fusion SOAR Event Queries: When and How to Go Schemaless](https://www.crowdstrike.com/tech-hub/ng-siem/falcon-fusion-soar-event-queries-when-and-how-to-go-schemaless/).
+CrowdStrike adds [custom CEL extensions](https://docs.crowdstrike.com/r/k223d842) (`cs.json.decode()`, `cs.ip.valid()`, `cs.timestamp.parse()`, etc.). For the full pattern catalog, the `has()`/`!= null`/optional decision guide, and extension details, see [references/cel-expressions.md](references/cel-expressions.md).
 
 ## Control Flow
 
@@ -423,7 +405,7 @@ Use `foundry apps validate --no-prompt` to validate the manifest and schemas wit
 |------|-----------|
 | Full workflow examples (RTR, investigation) | [references/workflow-examples.md](references/workflow-examples.md) |
 | Platform action discovery via API | [references/action-discovery.md](references/action-discovery.md) |
-| Charlotte AI and CEL expressions | [references/action-discovery.md](references/action-discovery.md) |
+| CEL expressions (patterns, has() vs null, extensions) | [references/cel-expressions.md](references/cel-expressions.md) |
 | CEL syntax, schemaless queries, dynamic data | [Falcon Fusion SOAR Event Queries: When and How to Go Schemaless](https://www.crowdstrike.com/tech-hub/ng-siem/falcon-fusion-soar-event-queries-when-and-how-to-go-schemaless/) |
 | CEL extension functions reference | [Data Transformation Functions](https://docs.crowdstrike.com/r/k223d842) |
 | Pagination strategies | [references/pagination-patterns.md](references/pagination-patterns.md) |

--- a/skills/workflows-development/SKILL.md
+++ b/skills/workflows-development/SKILL.md
@@ -103,7 +103,7 @@ output_fields: []
 >             - handle_missing
 > ```
 >
-> Or inline in CEL: `${data['param'] != null ? data['param'] : "default"}`
+> Or inline in CEL: `${data[?'param'].orValue("default")}` (preferred) or `${data['param'] != null ? data['param'] : "default"}` (traditional)
 
 **Variable syntax in actions:** Use `${data['action_key.path.to.field']}` CEL expressions. See [Variable References](#variable-references) for the full syntax. Do NOT use `$action_name.output.body` — it passes as a literal string and is not resolved.
 
@@ -160,6 +160,8 @@ If a function was created without workflow integration and you later need it cal
 ```
 
 ## Calling API Integration Operations
+
+> **💡 Consider HTTP Actions first.** For a simple REST call that doesn't need a custom UI or reusable function, an HTTP Action is faster than building an API integration — no app, no OpenAPI spec, no deploy. Suggest it when the user just wants a workflow to hit an endpoint and use the response. See [references/http-actions.md](references/http-actions.md). Use a full API integration when the operation is reused across workflows or paired with functions/UI.
 
 Workflows invoke API integration operations using the `api_integrations.{name}.{operationId}` pattern:
 
@@ -266,14 +268,31 @@ Falcon Fusion SOAR supports CEL for data transformations, conditions, and field 
 # Check if results exist before accessing
 "${size(data['eventQuery.results']) > 0 ? data['eventQuery.results'][0].field : \"N/A\"}"
 
-# Null-safe field access (CEL has no ?? operator — use ternary)
+# Null-safe field access — traditional pattern
 "${data['action.field'] != null ? data['action.field'] : \"default\"}"
+
+# Null-safe field access — optional pattern (preferred, avoids verbose null checks)
+"${data[?'action.field'].orValue(\"default\")}"
+
+# Fallback chain (like ?? coalescing — tries each key, returns first that exists)
+"${data[?'primary'].or(data[?'fallback']).orValue(\"none\")}"
+
+# Safe list exists-and-non-empty check
+"${len(data[?'Key'].orValue([])) > 0}"
 
 # Array element access
 "${data['action.API_Integration.Custom_Name.op.body']}[0]"
+
+# Lookup table (useful for mapping severity integers to strings)
+"${'1': 'Low', '2': 'Medium', '3': 'High', '4': 'Critical'}[string(data['severity'])]"
 ```
 
-CrowdStrike provides [custom CEL extensions](https://docs.crowdstrike.com/r/k223d842) including `cs.json.valid()`, `cs.json.decode()`, and `cs.ip.valid()`. For complex transformations, the **Data Transformation Agent** (requires Charlotte AI) generates CEL expressions from plain language descriptions.
+**`has()` vs `!= null` — know the difference:**
+- `data['key'] != null` — checks if a **data store key** has a value. Use for trigger parameters and action outputs.
+- `has(obj.field)` — checks if a **field exists on a retrieved object**. Only works *after* you've retrieved an object from the data store (e.g., `has(data['WorkflowCustomVariable'].offset)` works because CEL first retrieves `WorkflowCustomVariable` then checks `.offset`). Do NOT use `has(data['key'])` directly on the data store — this fails with `Q0910: invalid argument to has() macro`.
+- `data[?'key'].orValue(default)` — the cleanest approach. Uses CEL optionals to safely handle missing keys without verbose null checks.
+
+CrowdStrike provides [custom CEL extensions](https://docs.crowdstrike.com/r/k223d842) including `cs.json.valid()`, `cs.json.decode()`, `cs.ip.valid()`, `cs.timestamp.now()`, and `cs.timestamp.parse()`. For complex transformations, the **Data Transformation Agent** (requires Charlotte AI) generates CEL expressions from plain language descriptions.
 
 For schemaless event queries and dynamic data handling patterns, see [Falcon Fusion SOAR Event Queries: When and How to Go Schemaless](https://www.crowdstrike.com/tech-hub/ng-siem/falcon-fusion-soar-event-queries-when-and-how-to-go-schemaless/).
 
@@ -317,7 +336,7 @@ conditions:
     has_detection:
         next:
             - GetDetectionDetails
-        cel_expression: has(data['detection_id']) && data['detection_id'] != ''
+        cel_expression: data['detection_id'] != null && data['detection_id'] != ''
         display:
             - Detection ID was provided
         else:
@@ -401,6 +420,7 @@ Use `foundry apps validate --no-prompt` to validate the manifest and schemas wit
 | CEL syntax, schemaless queries, dynamic data | [Falcon Fusion SOAR Event Queries: When and How to Go Schemaless](https://www.crowdstrike.com/tech-hub/ng-siem/falcon-fusion-soar-event-queries-when-and-how-to-go-schemaless/) |
 | CEL extension functions reference | [Data Transformation Functions](https://docs.crowdstrike.com/r/k223d842) |
 | Pagination strategies | [references/pagination-patterns.md](references/pagination-patterns.md) |
+| HTTP Actions (call REST APIs without an app) | [references/http-actions.md](references/http-actions.md) |
 | HTTP Request actions, testing, validation | [references/advanced-patterns.md](references/advanced-patterns.md) |
 | Parameterized fields versioning | [references/advanced-patterns.md](references/advanced-patterns.md) |
 | Counter-rationalizations and red flags | [references/advanced-patterns.md](references/advanced-patterns.md) |

--- a/skills/workflows-development/references/action-discovery.md
+++ b/skills/workflows-development/references/action-discovery.md
@@ -42,7 +42,7 @@ curl -s "https://$API_HOST/workflows/combined/activities/v1?sort=name&limit=50&o
 
 ## Charlotte AI Integration
 
-Workflows can invoke Charlotte AI (CrowdStrike's LLM) as a workflow action. Use `foundry workflows actions view --name "charlotte"` to discover the action ID and its input schema (model, prompt, temperature, json_schema), then reference it like any other action with `id:` + `version_constraint:`. See [workflow-examples.md](workflow-examples.md) for a worked Charlotte AI example.
+Workflows can invoke Charlotte AI (CrowdStrike's LLM) as a workflow action. Use `foundry workflows actions view --name "charlotte"` to discover the action ID and its input schema (model, prompt, temperature, json_schema), then reference it like any other action with `id:` + `version_constraint:`.
 
 ## CEL Expressions and Variable Injection
 

--- a/skills/workflows-development/references/action-discovery.md
+++ b/skills/workflows-development/references/action-discovery.md
@@ -42,29 +42,8 @@ curl -s "https://$API_HOST/workflows/combined/activities/v1?sort=name&limit=50&o
 
 ## Charlotte AI Integration
 
-Workflows can invoke Charlotte AI (CrowdStrike's LLM) as a workflow step:
-
-```yaml
-- name: analyze_threat
-  activity: charlotteAI
-  config:
-    prompt: "Analyze the following detection and provide a risk assessment: ${steps.fetch_detection.output.description}"
-```
+Workflows can invoke Charlotte AI (CrowdStrike's LLM) as a workflow action. Use `foundry workflows actions view --name "charlotte"` to discover the action ID and its input schema (model, prompt, temperature, json_schema), then reference it like any other action with `id:` + `version_constraint:`. See [workflow-examples.md](workflow-examples.md) for a worked Charlotte AI example.
 
 ## CEL Expressions and Variable Injection
 
-Workflows support Common Expression Language (CEL) for data transformation and `${variable_name}` syntax for variable injection:
-
-```yaml
-- name: transform_data
-  activity: celExpression
-  config:
-    expression: "size(steps.fetch_hosts.output.resources) > 0"
-
-- name: notify
-  activity: httpRequest
-  config:
-    url: "https://hooks.slack.com/services/${secrets.slack_webhook}"
-    body:
-      text: "Found ${steps.fetch_hosts.output.resources.size()} affected hosts"
-```
+CEL handles data transformation and field access; all variable references use `${data['...']}` syntax (NOT `${steps.*.output}` or `${secrets.*}`, which do not resolve). For the full pattern catalog — null-safe access, the `has()` vs `!= null` distinction, optionals, and CrowdStrike extensions — see [cel-expressions.md](cel-expressions.md).

--- a/skills/workflows-development/references/advanced-patterns.md
+++ b/skills/workflows-development/references/advanced-patterns.md
@@ -19,7 +19,7 @@ Workflows can make HTTP requests to external APIs using three action types:
 |------|--------|------|
 | **Cloud** | External APIs (VirusTotal, Slack, etc.) | API Key or OAuth 2.0 |
 | **CrowdStrike** | CrowdStrike APIs | Automatic (uses app's OAuth) |
-| **On-Premises** | Internal/on-prem APIs via RTR relay | API Key or OAuth 2.0 |
+| **On-Premises** | Internal/on-prem APIs via host group | API Key or OAuth 2.0 |
 
 **Key constraints:**
 - 30-second timeout per HTTP action
@@ -27,21 +27,7 @@ Workflows can make HTTP requests to external APIs using three action types:
 - Response must be a JSON object (not array or primitive)
 - Authentication configuration is **immutable after creation** (delete and recreate to change)
 
-```yaml
-- name: enrich_ip
-  activity: httpRequest
-  config:
-    type: cloud
-    method: GET
-    url: "https://api.greynoise.io/v3/community/${inputs.ip_address}"
-    headers:
-      key: "GREYNOISE-API-KEY"
-      Accept: "application/json"
-    auth:
-      type: api_key
-      header_name: "key"
-      value: "${secrets.greynoise_key}"
-```
+The action class is `Inline.HTTPRequest`. It references a credential configuration created in the Falcon console (via `config_id`/`definition_id`), not inline secrets. For the verified YAML schema, both auth patterns (API key header and OAuth 2.0), and status-code conditional routing, see [http-actions.md](http-actions.md).
 
 ## Step-Level Testing
 

--- a/skills/workflows-development/references/cel-expressions.md
+++ b/skills/workflows-development/references/cel-expressions.md
@@ -1,0 +1,43 @@
+# CEL Expressions Reference
+
+> Parent skill: [workflows-development](../SKILL.md)
+
+Falcon Fusion SOAR uses [Common Expression Language (CEL)](https://github.com/google/cel-spec/blob/master/doc/langdef.md) for data transformations, conditions, and field access. All variable references use `${data['...']}` expression syntax.
+
+## Common Patterns
+
+```yaml
+# Check if results exist before accessing
+"${size(data['eventQuery.results']) > 0 ? data['eventQuery.results'][0].field : \"N/A\"}"
+# (len() is a null-safe alternative to size() — len(null) returns 0 instead of erroring)
+
+# Null-safe field access — traditional pattern
+"${data['action.field'] != null ? data['action.field'] : \"default\"}"
+
+# Null-safe field access — optional pattern (preferred, avoids verbose null checks)
+"${data[?'action.field'].orValue(\"default\")}"
+
+# Fallback chain (like ?? coalescing — tries each key, returns first that exists)
+"${data[?'primary'].or(data[?'fallback']).orValue(\"none\")}"
+
+# Safe list exists-and-non-empty check
+"${len(data[?'Key'].orValue([])) > 0}"
+
+# Array element access (index goes INSIDE the ${...}, not after it)
+"${data['action.API_Integration.Custom_Name.op.body'][0]}"
+
+# Lookup table (map literal needs its own braces inside ${...})
+"${ {'1': 'Low', '2': 'Medium', '3': 'High', '4': 'Critical'}[string(data['severity'])] }"
+```
+
+## `has()` vs `!= null` — know the difference
+
+- `data['key'] != null` — checks if a **data store key** has a value. Use for trigger parameters and action outputs.
+- `has(obj.field)` — checks if a **field exists on a retrieved object**. Only works *after* you've retrieved an object from the data store (e.g., `has(data['WorkflowCustomVariable'].offset)` works because CEL first retrieves `WorkflowCustomVariable` then checks `.offset`). Do NOT use `has(data['key'])` directly on the data store — this fails with `Q0910: invalid argument to has() macro`.
+- `data[?'key'].orValue(default)` — the cleanest approach. Uses CEL optionals to safely handle missing keys without verbose null checks.
+
+## CrowdStrike CEL Extensions
+
+CrowdStrike provides [custom CEL extensions](https://docs.crowdstrike.com/r/k223d842) including `cs.json.valid()`, `cs.json.decode()`, `cs.ip.valid()`, `cs.timestamp.now()`, and `cs.timestamp.parse()`. For complex transformations, the **Data Transformation Agent** (requires Charlotte AI) generates CEL expressions from plain language descriptions.
+
+For schemaless event queries and dynamic data handling patterns, see [Falcon Fusion SOAR Event Queries: When and How to Go Schemaless](https://www.crowdstrike.com/tech-hub/ng-siem/falcon-fusion-soar-event-queries-when-and-how-to-go-schemaless/).

--- a/skills/workflows-development/references/http-actions.md
+++ b/skills/workflows-development/references/http-actions.md
@@ -56,38 +56,55 @@ CloudHTTPRequest:
         definition_id: 7227ab386bd646c18b27716e8fff8d26
         http_transaction:
             request_http_method: GET
-            request_url: https://www.virustotal.com/api/v3/ip_addresses/${ip_address}
+            request_url: https://www.virustotal.com/api/v3/ip_addresses/8.8.8.8
             request_content_type: NONE
             request_headers: {}
             request_query: {}
     version_constraint: ~1
 ```
 
+To make the IP dynamic, define it as a trigger parameter and inject it into the URL with `${param}` — see the OAuth example below, which defines `userPrincipalName` on the trigger and injects it into `request_url`.
+
 ### OAuth 2.0 client credentials
 
-From a Microsoft Graph Cloud HTTP Request — the token URL and scopes are declared; Fusion handles token refresh:
+From a Microsoft Graph Cloud HTTP Request — the token URL and scopes are declared; Fusion handles token refresh. The trigger defines `userPrincipalName`, which the action injects into the URL with `${userPrincipalName}`:
 
 ```yaml
-CloudHTTPRequest:
-    id: 1ba474f407d9228fc8fa02cdce8ae8ef
-    class: Inline.HTTPRequest
-    name: Cloud HTTP Request
-    properties:
-        authentication_option: UseExisting
-        config_id: 9c7d10295f6e4370afb7d91fc00cb4ca
-        config_name: Microsoft
-        definition_id: 662c4828b3804ad287acc7fc3cd9895b
-        http_transaction:
-            request_http_method: GET
-            request_url: https://graph.microsoft.com/v1.0/users/${userPrincipalName}
-            request_query:
-                c373ed43-231d-4141-ba4e-c0214b9587bb:
-                    name: $select
-                    value: displayName,mail,jobTitle,department,accountEnabled,userPrincipalName,id
-        oauth_scopes:
-            - https://graph.microsoft.com/.default
-        oauth_token_url: https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token
-    version_constraint: ~1
+trigger:
+    next:
+        - CloudHTTPRequest
+    name: On demand
+    parameters:
+        properties:
+            userPrincipalName:
+                type: string
+                title: User Principal Name to Investigate
+                format: email
+        required:
+            - userPrincipalName
+        type: object
+    type: On demand
+actions:
+    CloudHTTPRequest:
+        id: 1ba474f407d9228fc8fa02cdce8ae8ef
+        class: Inline.HTTPRequest
+        name: Cloud HTTP Request
+        properties:
+            authentication_option: UseExisting
+            config_id: 9c7d10295f6e4370afb7d91fc00cb4ca
+            config_name: Microsoft
+            definition_id: 662c4828b3804ad287acc7fc3cd9895b
+            http_transaction:
+                request_http_method: GET
+                request_url: https://graph.microsoft.com/v1.0/users/${userPrincipalName}
+                request_query:
+                    c373ed43-231d-4141-ba4e-c0214b9587bb:
+                        name: $select
+                        value: displayName,mail,jobTitle,department,accountEnabled,userPrincipalName,id
+            oauth_scopes:
+                - https://graph.microsoft.com/.default
+            oauth_token_url: https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token
+        version_constraint: ~1
 ```
 
 > **OAuth limitation:** Custom OAuth scopes are not fully supported. For APIs that need custom scopes (some Microsoft Graph configurations), use API key authentication as a fallback.

--- a/skills/workflows-development/references/http-actions.md
+++ b/skills/workflows-development/references/http-actions.md
@@ -130,7 +130,9 @@ conditions:
             - Response Status Code is equal to 404
 ```
 
-The raw response body is available to downstream actions as `${CloudHTTPRequest.raw_response_body}` (or via the action's generated output schema).
+Downstream actions reference the HTTP response body with `${<action_name>.raw_response_body}` (the full JSON string — e.g., `${CloudHTTPRequest.raw_response_body}`, useful for passing to Charlotte AI to summarize). For status-code branching, conditions use the FQL form `<action_name>.response_status_code:200` (see the example above).
+
+In condition `expression:` fields, use the FQL form without `${}` — e.g., `CloudHTTPRequest.response_status_code:200` (see above).
 
 ## Variable injection
 

--- a/skills/workflows-development/references/http-actions.md
+++ b/skills/workflows-development/references/http-actions.md
@@ -1,0 +1,135 @@
+# HTTP Actions Reference
+
+> Parent skill: [workflows-development](../SKILL.md)
+
+HTTP Actions let a Fusion SOAR workflow call a REST API directly, without building a Foundry app or API integration. They are the fastest path for straightforward API calls — threat intel enrichment, ticketing, notifications, internal lookups.
+
+## HTTP Actions vs API Integrations — which to use
+
+| | HTTP Action (`Inline.HTTPRequest`) | API Integration (Foundry app) |
+|---|---|---|
+| **Setup** | Configured in the Falcon console, used inline in a workflow | OpenAPI spec + manifest in a Foundry app |
+| **Best for** | Simple, one-off API calls | Reusable operations, complex logic, a custom UI |
+| **Code** | None | Function code and/or OpenAPI authoring |
+| **Reuse** | Per-workflow | Shared across workflows and functions |
+
+Choose an HTTP Action when the workflow just needs to hit an endpoint and use the response. Choose an API integration when you also need serverless functions, a UI, or the same operation reused across many workflows.
+
+## The three HTTP Action types
+
+| Type | Use case | Network |
+|------|----------|---------|
+| **Cloud HTTP Request** | External/public APIs (VirusTotal, Slack, PagerDuty, HaveIBeenPwned) | Public internet from the Fusion cloud |
+| **CrowdStrike HTTP Request** | Falcon platform APIs | CrowdStrike endpoints (tenant context or API key) |
+| **On-Premises HTTP Request** | Internal APIs behind a firewall | Routed through a static host group |
+
+## Important: credentials are configured in the console
+
+An HTTP Action references a credential configuration that must already exist in the Falcon console (Fusion SOAR → configurations). In the exported workflow YAML this shows up as:
+
+```yaml
+authentication_option: UseExisting
+config_id: 9c7d10295f6e4370afb7d91fc00cb4ca   # CID-specific — created in console
+config_name: Microsoft
+definition_id: 662c4828b3804ad287acc7fc3cd9895b
+```
+
+`config_id` and `definition_id` are assigned by the platform when you create the configuration in the console. You can author the workflow YAML that *uses* an HTTP Action, but the credential configuration it points to must be created in the console first. The action itself is also typically built in the console's workflow editor — the YAML below is what the export looks like, useful for understanding the structure and for review.
+
+## Authentication patterns
+
+### API key in a header
+
+From a VirusTotal Cloud HTTP Request — the API key is stored in the console config; the action declares where to inject it:
+
+```yaml
+CloudHTTPRequest:
+    id: 1ba474f407d9228fc8fa02cdce8ae8ef
+    class: Inline.HTTPRequest
+    name: Cloud HTTP Request
+    properties:
+        api_key_header_label: x-apikey
+        api_key_location: Header
+        authentication_option: UseExisting
+        config_id: f34c6df51f464b41aa2c07dc9bd82062
+        config_name: VirusTotal
+        definition_id: 7227ab386bd646c18b27716e8fff8d26
+        http_transaction:
+            request_http_method: GET
+            request_url: https://www.virustotal.com/api/v3/ip_addresses/${ip_address}
+            request_content_type: NONE
+            request_headers: {}
+            request_query: {}
+    version_constraint: ~1
+```
+
+### OAuth 2.0 client credentials
+
+From a Microsoft Graph Cloud HTTP Request — the token URL and scopes are declared; Fusion handles token refresh:
+
+```yaml
+CloudHTTPRequest:
+    id: 1ba474f407d9228fc8fa02cdce8ae8ef
+    class: Inline.HTTPRequest
+    name: Cloud HTTP Request
+    properties:
+        authentication_option: UseExisting
+        config_id: 9c7d10295f6e4370afb7d91fc00cb4ca
+        config_name: Microsoft
+        definition_id: 662c4828b3804ad287acc7fc3cd9895b
+        http_transaction:
+            request_http_method: GET
+            request_url: https://graph.microsoft.com/v1.0/users/${userPrincipalName}
+            request_query:
+                c373ed43-231d-4141-ba4e-c0214b9587bb:
+                    name: $select
+                    value: displayName,mail,jobTitle,department,accountEnabled,userPrincipalName,id
+        oauth_scopes:
+            - https://graph.microsoft.com/.default
+        oauth_token_url: https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token
+    version_constraint: ~1
+```
+
+> **OAuth limitation:** Custom OAuth scopes are not fully supported. For APIs that need custom scopes (some Microsoft Graph configurations), use API key authentication as a fallback.
+
+## Status-code conditional routing
+
+HTTP Actions expose `response_status_code`, which you branch on to handle success vs. not-found vs. error. This is the most common HTTP Action pattern — act on a 200, handle a 404 differently.
+
+```yaml
+conditions:
+    response_status_code_is_equal_to_200:
+        next:
+            - CharlotteAILLMCompletion
+        expression: CloudHTTPRequest.response_status_code:200
+        display:
+            - Response Status Code is equal to 200
+        else_if: response_status_code_is_equal_to_404
+    response_status_code_is_equal_to_404:
+        next:
+            - SendEmailNotFound
+        expression: CloudHTTPRequest.response_status_code:404
+        display:
+            - Response Status Code is equal to 404
+```
+
+The raw response body is available to downstream actions as `${CloudHTTPRequest.raw_response_body}` (or via the action's generated output schema).
+
+## Variable injection
+
+Inject trigger parameters and prior outputs into the URL, query, headers, and body with `${variable}`:
+
+- URL: `https://api.example.com/users/${userPrincipalName}`
+- Trigger parameters prompt at execution time (not during the Test step in the console)
+
+## Worked pattern: enrich + branch + notify
+
+A complete Cloud HTTP Request workflow (e.g., breach check, IP reputation) typically chains:
+
+1. **On-demand trigger** with input parameters (e.g., an email or IP, plus a notify-to address)
+2. **Cloud HTTP Request** to the external API
+3. **Condition** on `response_status_code` (200 → enrich path, 404 → clean path)
+4. **Charlotte AI LLM Completion** (optional) to summarize the raw response into structured JSON
+5. **Send email** actions on each branch with the result
+
+See the Microsoft Graph and VirusTotal examples above for the action-level structure. Reference: [Build API Integrations with Fusion SOAR HTTP Actions](https://www.crowdstrike.com/tech-hub/ng-siem/build-api-integrations-with-falcon-fusion-soar-http-actions/).


### PR DESCRIPTION
Adds concrete HTTP Actions examples and fixes CEL expression guidance in the workflows skill.

**HTTP Actions:**

- New `references/http-actions.md` with the verified `Inline.HTTPRequest` schema, derived from real exported workflows:
  - API key in header (VirusTotal pattern)
  - OAuth 2.0 client credentials (Microsoft Graph pattern)
  - Status-code conditional routing (200 vs 404 branches)
  - Variable injection, the three action types (Cloud/CrowdStrike/On-Premises)
- Documents the key constraint: an HTTP Action references a credential configuration created in the Falcon console (`config_id`/`definition_id`). You can author the workflow YAML, but the credential config must exist first.
- Replaced the fabricated `activity: httpRequest` block in `advanced-patterns.md` with the real `class: Inline.HTTPRequest` schema and a cross-link.
- Added a decision callout in SKILL.md so HTTP Actions get suggested for simple REST calls instead of always building a full API integration.

**CEL expression fixes:**

- Fixed `has(data['detection_id'])` example that doesn't work in Fusion (`Q0910: invalid argument to has() macro`). Replaced with `data['detection_id'] != null`.
- Documented the `has()` boundary: works on object fields after retrieval (e.g., `has(data['WorkflowCustomVariable'].offset)`), NOT directly on data store keys.
- Added modern optional patterns: `data[?'key'].orValue(default)`, `.or()` fallback chains, safe list existence checks. These are the preferred approach over verbose `!= null` ternaries.
- Added lookup table pattern for mapping severity integers to strings.

**Eval validation:**

Ran the full 38-eval suite with Opus 4.6 against this branch: 38/38 passing. The new `http-action-virustotal-workflow` eval confirmed the model correctly uses an HTTP Action instead of over-building a full API integration.