### PR TITLE
Fix navigation useMemo to use React state (isInitialized)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 **UI:**
 - Vanilla JS as a first-class template option for pages and extensions. Includes CLI scaffolding examples, note that no npm install/build step is needed, and clarification that vite/build-related pitfalls are React-specific.
-- Async `connect()` callout explaining `falcon.connect()` must be in `useEffect` and navigation must be accessed after connect resolves via `useMemo` with `falcon.isConnected`.
+- Async `connect()` callout explaining `falcon.connect()` must be in `useEffect` and navigation must be accessed after connect resolves via `useMemo` with React state (`isInitialized`).
 
 **Workflows:**
 - HTTP Actions reference (`references/http-actions.md`) with verified `Inline.HTTPRequest` schema, both auth patterns (API key header and OAuth 2.0 client credentials), status-code conditional routing, and an HTTP-Actions-vs-API-integration decision guide. Added a callout so HTTP Actions are suggested for simple REST calls that don't need an app.

--- a/skills/ui-development/SKILL.md
+++ b/skills/ui-development/SKILL.md
@@ -145,12 +145,14 @@ const theme = await falcon.theme();
 document.documentElement.classList.add(`sl-theme-${theme}`);
 ```
 
-> **⚠️ `connect()` is async.** In React, `falcon.connect()` must be called inside a `useEffect` and navigation/theme must only be accessed AFTER connect resolves. Use `falcon.isConnected` as a dependency for `useMemo`:
+> **⚠️ `connect()` is async.** In React, `falcon.connect()` must be called inside a `useEffect` and navigation must only be accessed AFTER connect resolves. Use React state (`isInitialized`) as the `useMemo` dependency — not `falcon.isConnected` (which is a plain object property, not reactive state):
 >
 > ```jsx
+> const [isInitialized, setIsInitialized] = useState(false);
+> const falcon = useMemo(() => new FalconApi(), []);
 > const navigation = useMemo(() => {
->   return falcon.isConnected ? falcon.navigation : undefined;
-> }, [falcon.isConnected]);
+>   return isInitialized ? falcon.navigation : undefined;
+> }, [isInitialized]);
 > ```
 >
 > Gate child rendering on `isInitialized` state. See [references/react-patterns.md](references/react-patterns.md) for the full `FalconApiProvider` pattern.


### PR DESCRIPTION
Reflects CrowdStrike/foundry-js-blueprint-react#132 — `falcon.isConnected` is a plain object property, not reactive. Use `isInitialized` React state as the `useMemo` dependency.

The blueprint itself was fixed in foundry-js-blueprint-react#132. This updates the skill documentation to match the corrected pattern.