### PR TITLE
Force workflows-development sub-skill loading from orchestrator

### DIFF
--- a/skills/development-workflow/SKILL.md
+++ b/skills/development-workflow/SKILL.md
@@ -132,7 +132,7 @@ foundry apps validate --no-prompt
 foundry functions create --name "my-fn" --language python --description "desc" \
   --handler-name process --handler-method POST --handler-path /api/process --no-prompt
 
-# 5. Workflows
+# 5. Workflows — MUST load workflows-development sub-skill before writing the spec file
 foundry workflows create --name "My Workflow" --spec /tmp/My_workflow.yml --no-prompt
 
 # 6. UI pages (standalone full-page views)
@@ -151,10 +151,12 @@ foundry ui extensions create --name "my-ext" --description "desc" --from-templat
 The CLI scaffolds structure but cannot generate app logic. Delegate to sub-skills:
 
 - **OpenAPI spec** → api-integrations
-- **Workflow YAML** → workflows-development
+- **Workflow YAML** → workflows-development **(MUST load before writing ANY workflow YAML)**
 - **UI components** → ui-development
 - **Function handlers** → functions-development
 - **Collection schemas** → collections-development
+
+> **⚠️ MANDATORY: Load `workflows-development` before writing workflow YAML.** The workflow format is `trigger` + `actions` with `version_constraint` on every action. If you attempt workflow YAML without loading the sub-skill, you WILL hallucinate an incorrect format (`definition/node_types/sdk_type`) that does not exist and causes deploy failures. This is a known failure mode. ALWAYS load the sub-skill first.
 
 ### Step 7: Final Build and Deploy
 


### PR DESCRIPTION
A/B test showed 3/5 runs skipped loading `workflows-development`, causing the model to hallucinate a non-existent workflow YAML format (`definition/node_types/sdk_type`). This led to deploy failures and spiral debugging that inflated token usage from ~4M to ~18M per run (+153% regression).

When `workflows-development` WAS loaded, runs completed at baseline cost with zero deploy failures. This adds mandatory loading directives at both the Step 5 CLI command and Step 6 delegation points in `development-workflow/SKILL.md`.

The root cause is non-deterministic sub-skill loading. The orchestrator says to delegate to `workflows-development` but doesn't enforce it. With a larger context from recent PRs, the model is slightly less likely to proactively load the sub-skill and instead hallucinates the workflow format from training data.