### PR TITLE
Add GraphQL APIs use case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.4.0] - TBD
+
+### Added
+
+- **GraphQL APIs use case** — Integrate GraphQL APIs (Falcon Identity Protection, GitHub, Snyk) into Foundry apps using FalconPy or HTTP POST. Covers zero-arg auth for Falcon GraphQL endpoints and the security tradeoff of env vars vs API integrations for third-party APIs.
+
 ## [1.3.0] - 2026-06-11
 
 > Changes in this release were identified by running automated eval prompts against the skills with Sonnet and Opus, then investigating failures and judging feedback to find skill gaps.
@@ -112,7 +118,7 @@ Initial public release of Falcon Foundry Skills — AI coding assistant skills f
 
 ### Use Cases
 
-12 real-world implementation patterns extracted from [CrowdStrike Tech Hub](https://www.crowdstrike.com/tech-hub/ng-siem/) blog posts covering API pagination, detection enrichment, LogScale ingestion, custom SOAR actions, collections, and more.
+13 real-world implementation patterns extracted from [CrowdStrike Tech Hub](https://www.crowdstrike.com/tech-hub/ng-siem/) blog posts covering API pagination, detection enrichment, LogScale ingestion, custom SOAR actions, collections, GraphQL APIs, and more.
 
 ### Multi-Tool Support
 

--- a/use-cases/graphql-apis.md
+++ b/use-cases/graphql-apis.md
@@ -1,0 +1,85 @@
+---
+name: graphql-apis
+description: Integrate GraphQL APIs (Falcon Identity Protection, GitHub, Snyk) into Foundry apps using FalconPy or HTTP POST
+source: https://www.crowdstrike.com/tech-hub/ng-siem/working-with-graphql-apis-in-falcon-foundry/
+skills: [functions-development, functions-falcon-api]
+capabilities: [function]
+---
+
+## When to Use
+
+User wants to call a GraphQL API from a Foundry function — either a Falcon platform GraphQL endpoint (Identity Protection, Threat Graph) via FalconPy, or a third-party GraphQL API (GitHub, Snyk, Hasura) via HTTP POST. Also applies when the user asks about queries with fragments, variables, or nested response extraction.
+
+## Pattern
+
+### Falcon GraphQL APIs (FalconPy)
+
+FalconPy service classes handle authentication automatically inside Foundry functions (zero-arg constructor):
+
+```python
+from falconpy import IdentityProtection
+
+def handler(request, config):
+    idp = IdentityProtection()
+
+    query = """
+    {
+        entities(types: ["user"], first: 10, sortKey: RISK_SCORE, sortOrder: DESCENDING) {
+            nodes {
+                primaryDisplayName
+                riskScore
+                riskFactors { type severity }
+            }
+        }
+    }
+    """
+
+    response = idp.graphql(query=query)
+    return {"body": response["body"]["resources"]}
+```
+
+**Auth scopes needed:** Add `idp-graph:read` (or the relevant scope for the service) to the manifest.
+
+### Third-Party GraphQL APIs (HTTP POST)
+
+For external GraphQL endpoints, use environment variables for credentials and standard HTTP POST:
+
+```python
+import os
+import requests
+
+def handler(request, config):
+    token = os.environ.get("GITHUB_TOKEN")
+    query = """
+    query($owner: String!, $name: String!) {
+        repository(owner: $owner, name: $name) {
+            vulnerabilityAlerts(first: 10) {
+                nodes { securityVulnerability { severity package { name } } }
+            }
+        }
+    }
+    """
+    variables = {"owner": "CrowdStrike", "name": "foundry-skills"}
+
+    response = requests.post(
+        "https://api.github.com/graphql",
+        json={"query": query, "variables": variables},
+        headers={"Authorization": f"Bearer {token}"}
+    )
+    return {"body": response.json()}
+```
+
+**Security warning:** Environment variables are visible to anyone with App Developer privileges who exports the app. For production use, prefer API integrations (platform-managed credentials) over raw env vars. See the credential management decision table in the functions skill.
+
+### Key Differences from REST
+
+| Aspect | REST | GraphQL |
+|--------|------|---------|
+| Request | GET/POST to different endpoints | POST to single endpoint with query body |
+| Response shape | Fixed by the endpoint | Client specifies exactly what fields to return |
+| Auth in Foundry | API integration (preferred) or env vars | FalconPy (Falcon APIs) or env vars (third-party) |
+| Pagination | Offset/cursor in query params | Cursor in query variables (`after`, `first`) |
+
+## Sample App
+
+[foundry-sample-idp-notifications](https://github.com/CrowdStrike/foundry-sample-idp-notifications) — Queries Identity Protection GraphQL for risky users and timeline events, combines with REST methods from the same FalconPy service class.


### PR DESCRIPTION
Adds a new use case covering GraphQL API integration in Falcon Foundry, based on the Tech Hub article: https://www.crowdstrike.com/tech-hub/ng-siem/working-with-graphql-apis-in-falcon-foundry/

Covers two patterns:
- Falcon GraphQL APIs via FalconPy (zero-arg auth, Identity Protection example)
- Third-party GraphQL APIs via HTTP POST (GitHub example with env var credentials)

Includes the security warning about env vars vs API integrations for credential management, and a comparison table of REST vs GraphQL patterns in Foundry.