### PR TITLE
Fix invalid error-handling references in workflow advanced-patterns

### DIFF
--- a/skills/workflows-development/references/advanced-patterns.md
+++ b/skills/workflows-development/references/advanced-patterns.md
@@ -118,19 +118,19 @@ actions:
 | Your Excuse | Reality |
 |-------------|---------|
 | "YAML is simple, I don't need patterns" | Fusion YAML has execution semantics that standard YAML doesn't |
-| "I can chain API calls directly in code" | Workflows handle retries, state persistence, and parallelism automatically |
-| "I'll add error handling later" | Workflow failures without onError blocks corrupt state and lose context |
+| "I can chain API calls directly in code" | Workflows handle state persistence and parallelism automatically |
+| "I'll add error handling later" | Without conditional routing on `Workflow.Execution.Errors` and loop `continue_on_partial_execution`, failures abort the workflow and lose context |
 | "RTR is just like SSH" | RTR has session management, host targeting, and result aggregation built-in |
-| "forEach is overkill for small lists" | forEach with maxConcurrency prevents API rate limiting and resource exhaustion |
+| "A loop is overkill for small lists" | Sequential loops keep stateful and rate-limited actions from racing each other |
 | "Conditional logic belongs in Functions" | Workflow-level conditionals skip steps entirely, saving execution time |
 
 ## Red Flags - STOP Immediately
 
 If you catch yourself:
 - Writing raw API call chains in Functions instead of workflow steps
-- Creating multi-step workflows without onError blocks
+- Creating multi-step workflows without error routing (conditional branches on `Workflow.Execution.Errors`)
 - Hardcoding host IDs instead of using host groups or dynamic queries
-- Using unbounded parallel execution without maxConcurrency
+- Using concurrent loops (`sequential: false`) for stateful or rate-limited actions that should run sequentially
 - Storing secrets in workflow YAML instead of environment variables
 
 **STOP. Follow the patterns above. No shortcuts.**


### PR DESCRIPTION
The `skills/workflows-development/references/advanced-patterns.md` reference cited `onError` blocks, `maxConcurrency`, and automatic retries. None of these exist in Falcon Fusion workflows, and they directly contradicted the authoritative guidance in the same skill's `skills/workflows-development/SKILL.md`, which states that errors are handled through conditional routing and action-level flags (not `onError` blocks or retry middleware) and that no built-in retry or exponential backoff exists.

This updates the counter-rationalizations table and the red-flags list to reference the real mechanisms:

- Conditional routing on `Workflow.Execution.Errors` (CEL conditions like `data['Workflow.Execution.Errors'].size() > 0`)
- Loop `continue_on_partial_execution` for tolerating per-iteration failures
- Sequential loops (`sequential: true`) for stateful or rate-limited actions that should not race

It also replaces the `forEach`/`maxConcurrency` phrasing with the actual `loops:` construct used in Fusion YAML.

Verified against `skills/workflows-development/SKILL.md` (the same skill's error-handling section) and the real workflow YAML in foundry-tutorial-threat-hunting and foundry-sample-scalable-rtr.