### PR TITLE
Make eval harness model configurable via env var

### DIFF
--- a/test-skill.sh
+++ b/test-skill.sh
@@ -11,6 +11,9 @@
 #   ./test-skill.sh --baseline prev.json               # Run and compare against baseline
 #   ./test-skill.sh --save new.json --baseline old.json --runs 5  # Full A/B comparison
 #
+# Environment variables:
+#   EVAL_MODEL  — Model used to generate each app (default: opus, the latest Opus alias; set to sonnet to test with a weaker model)
+#
 set -euo pipefail
 
 RUNS=5
@@ -185,7 +188,7 @@ for i in $(seq 1 $RUNS); do
   FOUNDRY_SKIP_NAME_CONFIRM=1 env -u CLAUDECODE claude -p "$RUN_PROMPT" \
     ${PLUGIN_DIR_FLAGS[@]+"${PLUGIN_DIR_FLAGS[@]}"} \
     --dangerously-skip-permissions \
-    --model claude-opus-4-6 \
+    --model "${EVAL_MODEL:-opus}" \
     --verbose \
     --output-format stream-json \
     > "$LOG_FILE" 2>&1 &

--- a/verify-apps.sh
+++ b/verify-apps.sh
@@ -17,6 +17,7 @@
 #   FALCON_URL     — Falcon console URL (default: https://falcon.us-2.crowdstrike.com)
 #   SKIP_RELEASE   — Set to 1 to skip release step
 #   SKIP_BROWSER   — Set to 1 to run only Phase 1
+#   VERIFY_MODEL   — Model driving Phase 2 browser verification (default: opus, the latest Opus alias; set to sonnet to test with a weaker model)
 #
 set -euo pipefail
 
@@ -630,7 +631,7 @@ printf "  Log: %s\n\n" "$LOG_FILE"
 
 env -u CLAUDECODE claude -p "$BROWSER_PROMPT" \
   --dangerously-skip-permissions \
-  --model claude-opus-4-6 \
+  --model "${VERIFY_MODEL:-opus}" \
   --verbose \
   --output-format stream-json \
   > "$LOG_FILE" 2>&1 || true


### PR DESCRIPTION
The generation model in `test-skill.sh` and the Phase 2 browser-verification model in `verify-apps.sh` were both hardcoded to a specific version. Re-running the eval harness with a different model meant editing the scripts by hand each time.

Both now read their model from an environment variable, defaulting to the unversioned `opus` alias — the model these harnesses were developed against — when unset:

- `test-skill.sh` — app generation reads `EVAL_MODEL`
- `verify-apps.sh` — Phase 2 browser verification reads `VERIFY_MODEL`

The `opus` alias resolves to whatever Opus the running CLI supports, so the default is not a pinned version that could be unavailable for a given account. Set `EVAL_MODEL=sonnet` (or any explicit version) to test the skills against a weaker model, or pin a version for reproducible runs. Both variables are documented in the script headers.

Example:
```bash
EVAL_MODEL=sonnet ./test-skill.sh --runs 5      # test skills against a weaker model
VERIFY_MODEL=claude-opus-4-8 ./verify-apps.sh   # pin an explicit version
```

The haiku API-connectivity health check in `test-skill.sh` is intentionally left as-is.