### PR TITLE
Add mandatory sub-skill loading warnings for function code

### DIFF
--- a/skills/development-workflow/SKILL.md
+++ b/skills/development-workflow/SKILL.md
@@ -152,12 +152,20 @@ foundry ui extensions create --name "my-ext" --description "desc" --from-templat
 The CLI scaffolds structure but cannot generate app logic. Delegate to sub-skills:
 
 - **OpenAPI spec** → api-integrations
-- **Workflow YAML** → workflows-development **(MUST load before writing ANY workflow YAML)**
+- **Workflow YAML** → workflows-development
 - **UI components** → ui-development
 - **Function handlers** → functions-development
 - **Collection schemas** → collections-development
 
-> **⚠️ MANDATORY: Load `workflows-development` before writing workflow YAML.** The workflow format is `trigger` + `actions` with `version_constraint` on every action. If you attempt workflow YAML without loading the sub-skill, you WILL hallucinate an incorrect format (`definition/node_types/sdk_type`) that does not exist and causes deploy failures. This is a known failure mode. ALWAYS load the sub-skill first.
+> **⚠️ MANDATORY: Load the relevant sub-skill BEFORE writing any domain-specific code.** Without the sub-skill loaded, you WILL hallucinate incorrect formats and nonexistent APIs. Known failure modes:
+>
+> | Writing... | MUST load | Hallucination without it |
+> |---|---|---|
+> | Workflow YAML | `workflows-development` | Invented `definition/node_types/sdk_type` format instead of correct `trigger` + `actions` with `version_constraint` |
+> | Function code calling Falcon APIs or API integrations | `functions-falcon-api` | Invented `request.falcon_client.api_request(url='/foundry/entities/...')` or `request.api_integrations.execute(integration_name=...)` instead of FalconPy SDK classes (`from falconpy import Hosts`, `APIIntegrations`) |
+> | Function code accessing collections | `collections-development` | Invented REST endpoints for collection CRUD instead of FalconPy `CustomStorage` service class |
+>
+> ALWAYS load the sub-skill first. This is not optional.
 
 ### Step 7: Final Build and Deploy
 


### PR DESCRIPTION
The `development-workflow` skill had a mandatory warning for loading `workflows-development` before writing workflow YAML, but no equivalent for function code that calls Falcon APIs or accesses collections.

Eval results (Opus 4.6 run, foundry-skills-evals pipeline #268633) show that without these warnings, models hallucinate nonexistent API patterns:

- `request.falcon_client.api_request(url='/foundry/entities/collections/v1')`
- `request.api_integrations.execute(integration_name='Workday')`

Both are fabricated endpoints. The correct patterns use FalconPy SDK classes (`CustomStorage`, `APIIntegrations`, `Hosts`, etc.) which are documented in `functions-falcon-api` and `collections-development` sub-skills.

This adds two new mandatory warnings in Step 6 (Write Domain-Specific Content):

1. Load `functions-falcon-api` before writing function code that calls Falcon platform APIs or executes API integration operations
2. Load `collections-development` before writing function code that reads/writes Foundry collections

These mirror the existing mandatory warning for `workflows-development`.