### PR TITLE
Expand API integration routing to catch third-party service mentions

### DIFF
--- a/skills/development-workflow/SKILL.md
+++ b/skills/development-workflow/SKILL.md
@@ -70,12 +70,14 @@ Map user requests to Foundry capabilities:
 
 | User Says | Capability | CLI Command |
 |-----------|-----------|-------------|
-| "API integration", "connect to X API" | API Integration | `foundry api-integrations create` |
+| "API integration", "connect to X API", "hooks into X", "sends to X", "integrates with X" | API Integration | `foundry api-integrations create` |
 | "workflow", "on-demand", "automate" | Workflow | `foundry workflows create` |
 | "UI", "page", "dashboard" | UI Page | `foundry ui pages create` |
 | "extension", "sidebar", "widget" | UI Extension | `foundry ui extensions create` |
 | "function", "serverless", "backend" | Function | `foundry functions create` |
 | "store data", "collection", "database" | Collection | `foundry collections create` |
+
+> **⚠️ When the prompt mentions a third-party service (Slack, Jira, PagerDuty, ServiceNow, etc.), ALWAYS create an API integration for it.** The Foundry-native pattern is: API integration (OpenAPI spec) → workflow calls it as an action. Do NOT skip the API integration and call the service directly from a function — that bypasses Foundry's credential management and the action won't be available in Fusion SOAR workflows.
 
 ### Step 1b: Check for Known Patterns
 


### PR DESCRIPTION
The routing table in Step 1 (Parse Requirements) only matched explicit phrases like 'API integration' and 'connect to X API'. Prompts mentioning third-party services with phrasing like 'hooks into Slack' or 'sends to PagerDuty' were not routed to create an API integration. The agent would skip it and call the service directly from a function, bypassing Foundry's credential management.

Eval evidence: `slack-alert-notifications` failed 0/3 trials (consistently) because the agent created a function to call Slack directly instead of creating a Slack API integration + workflow action. The `api_integration_exists` check fails every time.

Changes:
- Expanded trigger phrases: 'hooks into X', 'sends to X', 'integrates with X'
- Added a mandatory warning that any third-party service mention must always get an API integration first