### PR TITLE
Add mandatory guidance for calling third-party APIs from functions

### DIFF
--- a/skills/development-workflow/SKILL.md
+++ b/skills/development-workflow/SKILL.md
@@ -162,7 +162,8 @@ The CLI scaffolds structure but cannot generate app logic. Delegate to sub-skill
 > | Writing... | MUST load | Hallucination without it |
 > |---|---|---|
 > | Workflow YAML | `workflows-development` | Invented `definition/node_types/sdk_type` format instead of correct `trigger` + `actions` with `version_constraint` |
-> | Function code calling Falcon APIs or API integrations | `functions-falcon-api` | Invented `request.falcon_client.api_request(url='/foundry/entities/...')` or `request.api_integrations.execute(integration_name=...)` instead of FalconPy SDK classes (`from falconpy import Hosts`, `APIIntegrations`) |
+> | Function code calling Falcon APIs | `functions-falcon-api` | Invented `request.falcon_client.api_request(url='/foundry/entities/...')` instead of FalconPy SDK classes (`from falconpy import Hosts`) |
+> | Function code calling a third-party API (Slack, Jira, PagerDuty, etc.) | `functions-falcon-api` + check `use-cases/` | Invented `falcon.command("createNotification")` or raw HTTP calls instead of `APIIntegrations().execute_command(definition_id="...", operation_id="...")`. The app MUST have an API integration (OpenAPI spec) for the service, then call it from the function via FalconPy `APIIntegrations` class. See foundry-sample-functions-python for reference. |
 > | Function code accessing collections | `collections-development` | Invented REST endpoints for collection CRUD instead of FalconPy `CustomStorage` service class |
 >
 > ALWAYS load the sub-skill first. This is not optional.


### PR DESCRIPTION
The agent hallucinates nonexistent platform APIs when trying to call third-party services (Slack, Jira, PagerDuty) from function code. For example, it invents `falcon.command("createNotification")` instead of using the correct pattern.

Eval evidence: `slack-alert-notifications` fails 0/3 trials consistently. The generated function calls a nonexistent platform notification API instead of using `APIIntegrations().execute_command(definition_id="SlackAPI", operation_id="chatPostMessage")`.

The correct pattern (documented in the [Dive into Functions with Python](https://www.crowdstrike.com/tech-hub/ng-siem/dive-into-falcon-foundry-functions-with-python/#calling-an-api-integration-from-a-falcon-foundry-function) blog post and foundry-sample-functions-python):

1. Create an API integration (OpenAPI spec) for the third-party service
2. Call it from function code via FalconPy `APIIntegrations` class

This PR splits the existing 'Falcon APIs or API integrations' row in the mandatory loading table into two explicit rows: one for Falcon platform APIs, one for third-party service calls via API integrations.