### PR TITLE
Fix action discovery for headless environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Added
 
 - **GraphQL APIs use case** — Integrate GraphQL APIs (Falcon Identity Protection, GitHub, Snyk) into Foundry apps using FalconPy or HTTP POST. Covers zero-arg auth for Falcon GraphQL endpoints and the security tradeoff of env vars vs API integrations for third-party APIs.
+- **`scripts/action_search.py`** — API-based action discovery script that works in headless/CI environments where the CLI's interactive `actions view` prompt fails. Uses FalconPy with FQL fuzzy matching and prints action IDs with `version_constraint` values.
+- **CLI guard for `actions view` / `triggers view`** — Hook now catches missing `--no-prompt` on these commands to prevent TTY hangs.
+
+### Fixed
+
+- **Action discovery guidance** — Updated all `actions view` examples to include `--no-prompt` and pointed to `action_search.py` as the primary fallback. The CLI ignores `--no-prompt` for these commands (tracked upstream), so the script is the reliable path.
 
 ## [1.3.0] - 2026-06-11
 

--- a/hooks/foundry-cli-guard.sh
+++ b/hooks/foundry-cli-guard.sh
@@ -118,6 +118,23 @@ if echo "$COMMAND" | grep -qE 'foundry\s+ui\s+extensions\b.*\bcreate\b'; then
   fi
 fi
 
+# Check for foundry workflows actions/triggers view without --no-prompt
+# The CLI currently ignores --no-prompt for these commands (FOUNDRY-3049) and
+# always launches an interactive Select() prompt. Adding --no-prompt is still
+# correct (for when the bug is fixed), but the real workaround is
+# scripts/action_search.py which queries the API directly.
+if echo "$COMMAND" | grep -qE 'foundry\s+workflows\s+(actions|triggers)\s+view\b'; then
+  if ! echo "$COMMAND" | grep -qF -- '--no-prompt'; then
+    jq -n '{
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        additionalContext: "The command is missing --no-prompt. The CLI currently ignores this flag for actions/triggers view (known bug), but add it anyway. If the command fails or hangs, use python3 scripts/action_search.py \"name\" instead — it queries the API directly and works in headless environments."
+      }
+    }'
+    exit 0
+  fi
+fi
+
 # Check for Foundry resource-creation commands — remind Claude to confirm name with user.
 # Only matches resource types (not profile create, which is local config).
 # Handles: --name "val", --name 'val', --name val, --name=val, --name="val", --name='val'

--- a/scripts/action_search.py
+++ b/scripts/action_search.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Search Foundry workflow actions by name via the CrowdStrike API.
+
+Usage:
+    python3 scripts/action_search.py "send email"
+    python3 scripts/action_search.py "contain" --details
+
+Reads credentials from the active Foundry CLI profile.
+Requires: falconpy, pyyaml (pip install crowdstrike-falconpy pyyaml)
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml  # pylint: disable=import-error
+from falconpy import Workflows  # pylint: disable=import-error
+
+
+def get_credentials():
+    """Read credentials from the active Foundry CLI profile."""
+    config_path = Path.home() / ".config" / "foundry" / "configuration.yml"
+    with open(config_path, encoding="utf-8") as f:
+        cfg = yaml.safe_load(f)
+    active = cfg.get("active_profile", cfg["profiles"][0]["name"])
+    profile = next(p for p in cfg["profiles"] if p["name"] == active)
+    region = profile.get("cloud_region", "us-1") or "us-1"
+    base_urls = {
+        "us-1": "https://api.crowdstrike.com",
+        "us-2": "https://api.us-2.crowdstrike.com",
+        "eu-1": "https://api.eu-1.crowdstrike.com",
+        "us-gov-1": "https://api.laggar.gcw.crowdstrike.com",
+        "us-gov-2": "https://api.us-gov-2.crowdstrike.com",
+    }
+    return {
+        "client_id": profile["credentials"]["api_client_id"],
+        "client_secret": profile["credentials"]["api_client_secret"],
+        "base_url": base_urls.get(region, base_urls["us-1"]),
+    }
+
+
+def search_actions(query, details=False):
+    """Search for workflow actions matching the query."""
+    creds = get_credentials()
+    falcon = Workflows(
+        client_id=creds["client_id"],
+        client_secret=creds["client_secret"],
+        base_url=creds["base_url"],
+    )
+
+    response = falcon.search_activities(
+        filter=f"name:~'{query}'",
+        sort="name",
+        limit=20,
+    )
+
+    if response["status_code"] != 200:
+        body = response["body"]
+        errors = body.get("errors", []) if isinstance(body, dict) else []
+        print(f"Error: {errors}", file=sys.stderr)
+        sys.exit(1)
+
+    body = response["body"]
+    resources = body.get("resources", []) if isinstance(body, dict) else []
+    if not resources:
+        print(f"No actions found matching '{query}'.")
+        sys.exit(0)
+
+    print(f"Found {len(resources)} action(s) matching '{query}':\n")
+    for r in resources:
+        sem = r.get("semantic_version", "")
+        constraint = f"~{sem.split('.')[0]}" if sem else "~0"
+
+        if details:
+            note = f"(semantic_version: {sem})" if sem else "(no semantic_version)"
+            print(f"  {r['name']}")
+            print(f"    id: {r['id']}")
+            print(f"    version_constraint: {constraint}  {note}")
+            props = r.get("properties", {})
+            if props:
+                print("    properties:")
+                for pname, pschema in props.items():
+                    req = " (required)" if pschema.get("required") else ""
+                    print(f"      {pname} [{pschema.get('type', '?')}]{req}")
+            print()
+        else:
+            print(f"  {r['id']}: {r['name']}  (version_constraint: {constraint})")
+
+
+def main():
+    """Parse arguments and run the action search."""
+    parser = argparse.ArgumentParser(description="Search Foundry workflow actions")
+    parser.add_argument("query", help="Action name to search for (fuzzy match)")
+    parser.add_argument("--details", action="store_true",
+                        help="Show full details including properties")
+    args = parser.parse_args()
+    search_actions(args.query, details=args.details)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/workflows-development/SKILL.md
+++ b/skills/workflows-development/SKILL.md
@@ -44,13 +44,13 @@ foundry workflows create --name "my-workflow" --spec /tmp/workflow.yaml --no-pro
 ### Discover Available Actions and Triggers
 
 ```bash
-foundry workflows actions view --name "send email"   # Look up by name (fuzzy matching)
-foundry workflows actions view --name "send email" --output-schema  # Get output schema
-foundry workflows actions view --name "send email" --mock           # Get mock output example
-foundry workflows triggers view                                      # List available triggers
+foundry workflows actions view --name "send email" --no-prompt              # Look up by name
+foundry workflows actions view --name "send email" --no-prompt --output-schema  # Output schema
+foundry workflows actions view --name "send email" --no-prompt --mock       # Mock output
+foundry workflows triggers view --no-prompt                                 # List triggers
 ```
 
-Pass `--name` to avoid a known macOS bug where the interactive selector hangs. The `--name` filter uses fuzzy matching, so partial names work (e.g., `--name "send"` finds "send email"). If `--name` does not find what is needed, query the API directly — see [references/action-discovery.md](references/action-discovery.md).
+> **⚠️ Always use `--no-prompt` on `actions view` and `triggers view`.** The `--name` filter is fuzzy — partial matches trigger an interactive prompt that fails in headless environments (`Error: no TTY available`). If the CLI errors or hangs, use `python3 scripts/action_search.py "name"` instead — see [references/action-discovery.md](references/action-discovery.md).
 
 ## Workflow Structure
 
@@ -112,7 +112,7 @@ output_fields: []
 - `~0` = activity has **no** `semantic_version` defined (functions, API integrations, and some platform actions like "contain device")
 - `~1` = activity **has** a `semantic_version` (most platform actions: Print data, Send email, Create/Update variable, Get device details, etc.)
 
-Use `foundry workflows actions view --name "<action>"` to check. If the activity output shows a semantic_version field, use `~1`. If it does not, use `~0`.
+Use `foundry workflows actions view --name "<action>" --no-prompt` to check. If the activity output shows a semantic_version field, use `~1`. If it does not, use `~0`.
 
 ```yaml
 actions:
@@ -213,7 +213,7 @@ Platform actions (send email, log output, create detection) require platform-spe
 | Get device details | `6265dc947cc2252f74a5f25261ac36a9` |
 | Contain device | `bec9fbeb4999d207937854fd56088107` |
 
-For actions not in this table, use `foundry workflows actions view --name "..."` or the API query in [references/action-discovery.md](references/action-discovery.md). There are 9,000+ platform actions available. MUST NOT guess action IDs — use discovery commands.
+For actions not in this table, use `foundry workflows actions view --name "..." --no-prompt` or the API query in [references/action-discovery.md](references/action-discovery.md). There are 9,000+ platform actions available. MUST NOT guess action IDs — use discovery commands.
 
 ### Common Action Properties
 
@@ -390,8 +390,8 @@ No built-in retry or exponential backoff exists. For pagination polling, use a `
 ## Testing
 
 ```bash
-foundry workflows triggers view --mock       # Example mock trigger
-foundry workflows actions view --mock        # Example mock action
+foundry workflows triggers view --mock --no-prompt       # Example mock trigger
+foundry workflows actions view --mock --no-prompt        # Example mock action
 foundry workflows executions validate --mocks mymocks.json              # Validate mocks
 foundry workflows executions start --definition my-workflow --mocks mymocks.json  # Run with mocks
 foundry workflows executions view <execution_id>                        # View results

--- a/skills/workflows-development/references/action-discovery.md
+++ b/skills/workflows-development/references/action-discovery.md
@@ -2,9 +2,21 @@
 
 > Parent skill: [workflows-development](../SKILL.md)
 
-## API Query Script for Platform Actions
+## action_search.py (preferred)
 
-When `foundry workflows actions view --name "..."` does not find what is needed, query the API directly using credentials from `~/.config/foundry/configuration.yml`:
+Use `scripts/action_search.py` to search for platform actions by name. This script queries the API directly and works in headless/CI environments where the CLI's interactive prompt fails:
+
+```bash
+python3 scripts/action_search.py "send email"              # Search by name (fuzzy)
+python3 scripts/action_search.py "contain" --details       # Full details with properties
+python3 scripts/action_search.py "get alerts v2"           # Specific action
+```
+
+The script reads credentials from the active Foundry CLI profile, authenticates via OAuth, and prints action IDs with their `version_constraint` values.
+
+## Manual API Query
+
+When the script is not available, query the API directly using credentials from `~/.config/foundry/configuration.yml`:
 
 ```bash
 # 1. Read credentials from the active Foundry profile
@@ -42,7 +54,7 @@ curl -s "https://$API_HOST/workflows/combined/activities/v1?sort=name&limit=50&o
 
 ## Charlotte AI Integration
 
-Workflows can invoke Charlotte AI (CrowdStrike's LLM) as a workflow action. Use `foundry workflows actions view --name "charlotte"` to discover the action ID and its input schema (model, prompt, temperature, json_schema), then reference it like any other action with `id:` + `version_constraint:`.
+Workflows can invoke Charlotte AI (CrowdStrike's LLM) as a workflow action. Use `foundry workflows actions view --name "charlotte" --no-prompt` to discover the action ID and its input schema (model, prompt, temperature, json_schema), then reference it like any other action with `id:` + `version_constraint:`.
 
 ## CEL Expressions and Variable Injection
 

--- a/skills/workflows-development/references/advanced-patterns.md
+++ b/skills/workflows-development/references/advanced-patterns.md
@@ -105,13 +105,13 @@ actions:
         version_constraint: ~0
 
     # TODO: Configure this action in Falcon App Builder — use
-    # foundry workflows actions view --name "send email" to discover the action ID
+    # foundry workflows actions view --name "send email" --no-prompt to discover the action ID
     # send_notification:
-    #     id: <find via foundry workflows actions view --name "..." or App Builder>
+    #     id: <find via foundry workflows actions view --name "..." --no-prompt or App Builder>
     #     properties: {}
 ```
 
-> **Common mistake:** Guessing platform action IDs (e.g., `send_email`, `log`). These are not valid. Use `foundry workflows actions view --name "..."` to discover valid IDs, use the `api_integrations.{name}.{operationId}` pattern for API integration actions, or set `provision_on_install: false` and configure platform actions in the Falcon console.
+> **Common mistake:** Guessing platform action IDs (e.g., `send_email`, `log`). These are not valid. Use `foundry workflows actions view --name "..." --no-prompt` to discover valid IDs, use the `api_integrations.{name}.{operationId}` pattern for API integration actions, or set `provision_on_install: false` and configure platform actions in the Falcon console.
 
 ## Counter-Rationalizations Table
 

--- a/skills/workflows-development/references/workflow-examples.md
+++ b/skills/workflows-development/references/workflow-examples.md
@@ -96,7 +96,7 @@ output_fields: []
 Platform response actions (contain device, lift containment, create IOC) use discovered action IDs. To find the ID, run:
 
 ```bash
-foundry workflows actions view --name "contain"
+foundry workflows actions view --name "contain" --no-prompt
 ```
 
 This example demonstrates an on-demand workflow that contains a host by device ID, with a null-guard condition to prevent runtime errors when the parameter is empty.
@@ -140,13 +140,13 @@ conditions:
 ```
 
 **Patterns demonstrated:**
-- Discovering platform actions via `foundry workflows actions view --name "..."`
+- Discovering platform actions via `foundry workflows actions view --name "..." --no-prompt`
 - `conditions:` with `cel_expression:` for null-guarding trigger parameters
 - `else:` routing to a fallback action when the parameter is missing
 - Response action pattern with a real platform action ID (`bec9fbeb4999d207937854fd56088107` = Contain device)
 - CEL null-guard: `data['field'] != null && data['field'] != ''`
 
-> **⚠️ Always discover action IDs** — do NOT guess or hardcode IDs from this example for other actions. Use `foundry workflows actions view --name "..."` or the API query in [action-discovery.md](action-discovery.md) to find the correct ID for your specific use case.
+> **⚠️ Always discover action IDs** — do NOT guess or hardcode IDs from this example for other actions. Use `foundry workflows actions view --name "..." --no-prompt` or the API query in [action-discovery.md](action-discovery.md) to find the correct ID for your specific use case.
 
 ## Scheduled Workflow with Pagination Loop
 


### PR DESCRIPTION
The CLI `foundry workflows actions view` ignores `--no-prompt` and always opens an interactive selector — confirmed on CLI 2.0.2. This causes `Error: no TTY available` in Claude Code and CI, or hangs indefinitely when only one action matches.

Changes:
- Add `scripts/action_search.py` — a deterministic API-based action search using FalconPy that works in all environments. Uses FQL fuzzy matching, prints action IDs with `version_constraint` values.
- Update skill guidance to point to the script as the primary fallback when the CLI fails
- Add `--no-prompt` to all `actions view` / `triggers view` examples (correct for when the CLI bug is fixed)
- Add CLI guard hook check that acknowledges the bug and directs to the script