### PR TITLE
Steer Falcon alert and detection queries to FalconPy functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Fixed
 
 - **Action discovery guidance** — Updated all `actions view` examples to include `--no-prompt` and pointed to `action_search.py` as the primary fallback. The CLI ignores `--no-prompt` for these commands (tracked upstream), so the script is the reliable path.
+- **Alert and detection queries steer to FalconPy functions** — The orchestrator and workflows skills now direct Falcon platform alert, detection, and incident queries to a FalconPy `Alerts`/`Detects` function instead of a workflow Event Query action, whose NG-SIEM/LogScale results depend on the customer's ingestion connectors and can silently return no alerts. The functions-falcon-api alert example now demonstrates the `severity_name` + `created_timestamp` FQL filter.
 
 ## [1.3.0] - 2026-06-11
 

--- a/skills/development-workflow/SKILL.md
+++ b/skills/development-workflow/SKILL.md
@@ -77,6 +77,8 @@ Map user requests to Foundry capabilities:
 | "function", "serverless", "backend" | Function | `foundry functions create` |
 | "store data", "collection", "database" | Collection | `foundry collections create` |
 
+> **⚠️ "Summarize/query alerts, detections, or incidents" implies a function.** Falcon platform alert and detection data must be fetched with the FalconPy `Alerts`/`Detects` classes from inside a function — it is NOT reliably queryable via a workflow Event Query action (that runs against NG-SIEM/LogScale repos, whose contents depend on the customer's ingestion connectors). So a request like "a workflow that emails a summary of high-severity alerts" needs BOTH a function (to query alerts via FalconPy) AND a workflow (to schedule it and send email) — plan the `alerts:read` scope and the function up front. See [functions-falcon-api](../functions-falcon-api/SKILL.md).
+
 ### Step 1b: Check for Known Patterns
 
 Before scaffolding, check if the user's request matches a known use case. Glob `use-cases/*.md` and scan the `description` field in each file's frontmatter. If a match is found, read the use case file for implementation context (architecture, capability order, gotchas) before proceeding.

--- a/skills/functions-falcon-api/SKILL.md
+++ b/skills/functions-falcon-api/SKILL.md
@@ -46,7 +46,13 @@ def get_alerts(request: Request, config: Union[Dict[str, Any], None], logger: Lo
     falcon = Alerts()  # Zero-arg constructor — auth is automatic
 
     limit = min(int(request.params.get("limit", 50)), 100)
-    response = falcon.query_alerts_v2(limit=limit)
+    # FQL filter: high-severity alerts from the last 24 hours.
+    # Combine conditions with '+' (AND); relative times like 'now-24h' are supported.
+    response = falcon.query_alerts_v2(
+        filter="severity_name:'High'+created_timestamp:>'now-24h'",
+        limit=limit,
+        sort="created_timestamp|desc",
+    )
 
     if response["status_code"] != 200:
         logger.error(f"Failed to query alerts: {response.get('errors')}")

--- a/skills/workflows-development/SKILL.md
+++ b/skills/workflows-development/SKILL.md
@@ -159,13 +159,7 @@ If a function was created without workflow integration and you later need it cal
 ❌ Error: referenced function '{name}' and handler '{handler}' does not have workflow_integration properties defined
 ```
 
-> **⚠️ Querying Falcon platform alerts, detections, or incidents? Use a FalconPy function — NOT an Event Query action.**
->
-> The Event Query action (`Inline.QueryEvent`) runs against NG-SIEM/LogScale repositories (`xdr*`, `search-all`, etc.). Whether Falcon alerts and detections are present there — and in what schema — depends entirely on the customer's NG-SIEM ingestion connectors. A base tenant with no connectors returns audit logs, not alerts. So an Event Query for "high-severity alerts" **silently returns zero or wrong results** on many tenants.
->
-> The reliable, tenant-independent path is a function that calls the FalconPy `Alerts` class (`query_alerts_v2` + `get_alerts_v2`), then wire the function into the workflow. `query_alerts_v2` accepts an FQL `filter` such as `severity_name:'High'+created_timestamp:>'now-24h'` and works on every tenant regardless of NG-SIEM config. See [functions-falcon-api](../functions-falcon-api/SKILL.md) for the handler pattern and OAuth scopes (`alerts:read`).
->
-> Use an Event Query only for data that genuinely lives in NG-SIEM (ingested third-party logs, custom parsers, LogScale search results) — see [ngsiem-query-export.md](../../use-cases/ngsiem-query-export.md).
+> **⚠️ Querying Falcon alerts, detections, or incidents? Use a FalconPy function, NOT an Event Query action.** `Inline.QueryEvent` runs against NG-SIEM/LogScale repos whose alert contents depend on customer ingestion connectors, so it can silently return nothing. Instead call FalconPy `Alerts` (`query_alerts_v2`, FQL `filter="severity_name:'High'+created_timestamp:>'now-24h'"`) from a function and wire it in — see [functions-falcon-api](../functions-falcon-api/SKILL.md) (needs `alerts:read`). Reserve Event Query for data that truly lives in NG-SIEM.
 
 ## Calling API Integration Operations
 
@@ -364,36 +358,7 @@ workflows:
 
 ## Error Handling
 
-Foundry workflows handle errors through conditional routing and action-level flags — not `onError` blocks or retry middleware.
-
-| Mechanism | Scope | Usage |
-|-----------|-------|-------|
-| `fail_fast_enabled: false` | Function actions | Allow workflow to continue if a function call fails |
-| `continue_on_partial_execution: true` | Loop `for:` block | Continue loop if individual iterations fail |
-| `continue_on_partial_execution: false` | Loop `for:` block | Stop entire loop on first failure (default safe choice) |
-| `conditions:` with `else:` | Action routing | Route to fallback action when condition is false |
-
-```yaml
-# Function-level: suppress non-critical failures
-actions:
-    enrich_data:
-        id: functions.enrichment.Enrich
-        properties:
-            fail_fast_enabled: false
-        version_constraint: ~0
-        next:
-            - process_results
-
-# Loop-level: stop on first error
-loops:
-    ContainDevices:
-        for:
-            input: device_ids
-            continue_on_partial_execution: false
-            sequential: true
-```
-
-No built-in retry or exponential backoff exists. For pagination polling, use a `loops:` block with a cursor variable — see [references/pagination-patterns.md](references/pagination-patterns.md).
+Foundry workflows handle errors through conditional routing and action-level flags — not `onError` blocks or retry middleware. Key mechanisms: `fail_fast_enabled: false` (function actions), `continue_on_partial_execution` (loop blocks), and `conditions:`/`else:` routing. No built-in retry or backoff exists. For the full table, examples, and pagination-polling pattern, see [references/advanced-patterns.md](references/advanced-patterns.md).
 
 ## Testing
 
@@ -419,6 +384,7 @@ Use `foundry apps validate --no-prompt` to validate the manifest and schemas wit
 | Pagination strategies | [references/pagination-patterns.md](references/pagination-patterns.md) |
 | HTTP Actions (call REST APIs without an app) | [references/http-actions.md](references/http-actions.md) |
 | HTTP Request actions, testing, validation | [references/advanced-patterns.md](references/advanced-patterns.md) |
+| Error handling (fail_fast, partial execution, routing) | [references/advanced-patterns.md](references/advanced-patterns.md) |
 | Parameterized fields versioning | [references/advanced-patterns.md](references/advanced-patterns.md) |
 | Counter-rationalizations and red flags | [references/advanced-patterns.md](references/advanced-patterns.md) |
 

--- a/skills/workflows-development/SKILL.md
+++ b/skills/workflows-development/SKILL.md
@@ -159,6 +159,14 @@ If a function was created without workflow integration and you later need it cal
 ❌ Error: referenced function '{name}' and handler '{handler}' does not have workflow_integration properties defined
 ```
 
+> **⚠️ Querying Falcon platform alerts, detections, or incidents? Use a FalconPy function — NOT an Event Query action.**
+>
+> The Event Query action (`Inline.QueryEvent`) runs against NG-SIEM/LogScale repositories (`xdr*`, `search-all`, etc.). Whether Falcon alerts and detections are present there — and in what schema — depends entirely on the customer's NG-SIEM ingestion connectors. A base tenant with no connectors returns audit logs, not alerts. So an Event Query for "high-severity alerts" **silently returns zero or wrong results** on many tenants.
+>
+> The reliable, tenant-independent path is a function that calls the FalconPy `Alerts` class (`query_alerts_v2` + `get_alerts_v2`), then wire the function into the workflow. `query_alerts_v2` accepts an FQL `filter` such as `severity_name:'High'+created_timestamp:>'now-24h'` and works on every tenant regardless of NG-SIEM config. See [functions-falcon-api](../functions-falcon-api/SKILL.md) for the handler pattern and OAuth scopes (`alerts:read`).
+>
+> Use an Event Query only for data that genuinely lives in NG-SIEM (ingested third-party logs, custom parsers, LogScale search results) — see [ngsiem-query-export.md](../../use-cases/ngsiem-query-export.md).
+
 ## Calling API Integration Operations
 
 > **💡 Consider HTTP Actions first.** For a simple REST call that doesn't need a custom UI or reusable function, an HTTP Action is faster than an API integration — no app, no OpenAPI spec, no deploy. Use a full API integration when the operation is reused across workflows or paired with functions/UI. See [references/http-actions.md](references/http-actions.md).

--- a/skills/workflows-development/references/advanced-patterns.md
+++ b/skills/workflows-development/references/advanced-patterns.md
@@ -79,6 +79,39 @@ npx @redocly/cli lint api-integrations/MyApi.yaml
   timeout: 300  # 5 minutes per step
 ```
 
+## Error Handling
+
+Foundry workflows handle errors through conditional routing and action-level flags — not `onError` blocks or retry middleware.
+
+| Mechanism | Scope | Usage |
+|-----------|-------|-------|
+| `fail_fast_enabled: false` | Function actions | Allow workflow to continue if a function call fails |
+| `continue_on_partial_execution: true` | Loop `for:` block | Continue loop if individual iterations fail |
+| `continue_on_partial_execution: false` | Loop `for:` block | Stop entire loop on first failure (default safe choice) |
+| `conditions:` with `else:` | Action routing | Route to fallback action when condition is false |
+
+```yaml
+# Function-level: suppress non-critical failures
+actions:
+    enrich_data:
+        id: functions.enrichment.Enrich
+        properties:
+            fail_fast_enabled: false
+        version_constraint: ~0
+        next:
+            - process_results
+
+# Loop-level: stop on first error
+loops:
+    ContainDevices:
+        for:
+            input: device_ids
+            continue_on_partial_execution: false
+            sequential: true
+```
+
+No built-in retry or exponential backoff exists. For pagination polling, use a `loops:` block with a cursor variable — see [pagination-patterns.md](pagination-patterns.md).
+
 ## Platform Action Fallback Strategy
 
 If you don't know the exact action name:


### PR DESCRIPTION
Falcon platform alerts, detections, and incidents are not reliably queryable via a Fusion workflow Event Query action. That action runs against NG-SIEM/LogScale repositories, and whether alert data is present there — and in what schema — depends entirely on the customer's ingestion connectors. A tenant with no connectors gets audit log events, not alerts, so an Event Query for "high-severity alerts" can silently return zero results.

The reliable, tenant-independent path is a function that calls the FalconPy `Alerts` (or `Detects`) class and wires into the workflow. This adds guidance to that effect in three places:

- **development-workflow** orchestrator — a request like "a workflow that emails a summary of high-severity alerts" is now planned as a function *plus* a workflow (with the `alerts:read` scope) up front, rather than a workflow alone.
- **workflows-development** — a decision callout on when to use a FalconPy function vs an Event Query action.
- **functions-falcon-api** — the alert example now shows a concrete FQL filter (`severity_name:'High'+created_timestamp:>'now-24h'`) with `sort`, instead of an unfiltered query.

The FQL filter was verified against the live Alerts API: `severity_name` is the correct field for High/Critical severity (the numeric `severity` field is a different scale), and `query_alerts_v2` returns alerts across all products by default.