### PR TITLE
Rename Python scripts to snake_case

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run spec adaptation tests
         run: |
           source .venv/bin/activate
-          python scripts/test-adapt-spec.py
+          python scripts/test_adapt_spec.py
 
   validate:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - **`scripts/action_search.py`** — API-based action discovery script that works in headless/CI environments where the CLI's interactive `actions view` prompt fails. Uses FalconPy with FQL fuzzy matching and prints action IDs with `version_constraint` values.
 - **CLI guard for `actions view` / `triggers view`** — Hook now catches missing `--no-prompt` on these commands to prevent TTY hangs.
 
+### Changed
+
+- **Renamed Python scripts to snake_case** — `scripts/adapt-spec-for-foundry.py` → `adapt_spec_for_foundry.py` and `scripts/test-adapt-spec.py` → `test_adapt_spec.py`, matching the repo's `snake_case` lint convention and allowing the test to import the module directly. The PreToolUse hook and all skill docs reference the new names; no behavior changed. If you invoked the old path directly in your own tooling, update it to the underscore name.
+
 ### Fixed
 
 - **Action discovery guidance** — Updated all `actions view` examples to include `--no-prompt` and pointed to `action_search.py` as the primary fallback. The CLI ignores `--no-prompt` for these commands (tracked upstream), so the script is the reliable path.

--- a/hooks/foundry-skill-router.sh
+++ b/hooks/foundry-skill-router.sh
@@ -79,7 +79,7 @@ case "$HOOK_EVENT" in
         if [ -n "$SPEC_FILE" ] && [ -f "$SPEC_FILE" ]; then
           # Find the adapt script relative to the plugin root
           PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-          ADAPT_SCRIPT="$PLUGIN_ROOT/scripts/adapt-spec-for-foundry.py"
+          ADAPT_SCRIPT="$PLUGIN_ROOT/scripts/adapt_spec_for_foundry.py"
 
           # Run the adapt script automatically to fix known issues
           if [ -f "$ADAPT_SCRIPT" ]; then
@@ -101,7 +101,7 @@ case "$HOOK_EVENT" in
                 jq -n --arg output "$ADAPT_OUTPUT" '{
                   hookSpecificOutput: {
                     hookEventName: "PreToolUse",
-                    additionalContext: ("adapt-spec-for-foundry.py automatically fixed the spec before import:\n" + $output + "\nProceeding with the corrected spec.")
+                    additionalContext: ("adapt_spec_for_foundry.py automatically fixed the spec before import:\n" + $output + "\nProceeding with the corrected spec.")
                   }
                 }'
                 exit 0
@@ -112,7 +112,7 @@ case "$HOOK_EVENT" in
               hookSpecificOutput: {
                 hookEventName: "PreToolUse",
                 decision: "block",
-                reason: ("BLOCKED: adapt-spec-for-foundry.py not found at " + $script + ". This script is required to validate OpenAPI specs before import.")
+                reason: ("BLOCKED: adapt_spec_for_foundry.py not found at " + $script + ". This script is required to validate OpenAPI specs before import.")
               }
             }'
             exit 0

--- a/scripts/adapt_spec_for_foundry.py
+++ b/scripts/adapt_spec_for_foundry.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # pylint: disable=invalid-name
 """
-adapt-spec-for-foundry.py — Transform OpenAPI specs for Falcon Foundry
+adapt_spec_for_foundry.py — Transform OpenAPI specs for Falcon Foundry
 
 Applies deterministic transformations derived from 12 production Foundry sample apps:
   1. Swagger 2.0 conversion: Convert to OpenAPI 3.0 via swagger2openapi (npx)
@@ -13,9 +13,9 @@ Does NOT add x-cs-operation-config — which operations to expose to workflows i
 prompt-driven decision the agent makes based on user requirements.
 
 Usage:
-  python3 scripts/adapt-spec-for-foundry.py /tmp/VendorApi.yaml
-  python3 scripts/adapt-spec-for-foundry.py /tmp/VendorApi.json -o /tmp/adapted.json
-  python3 scripts/adapt-spec-for-foundry.py spec.yaml --dry-run
+  python3 scripts/adapt_spec_for_foundry.py /tmp/VendorApi.yaml
+  python3 scripts/adapt_spec_for_foundry.py /tmp/VendorApi.json -o /tmp/adapted.json
+  python3 scripts/adapt_spec_for_foundry.py spec.yaml --dry-run
 """
 
 import argparse

--- a/scripts/test_adapt_spec.py
+++ b/scripts/test_adapt_spec.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Tests for adapt-spec-for-foundry.py"""
+"""Tests for adapt_spec_for_foundry.py"""
 # pylint: disable=invalid-name,wrong-import-position,global-statement
 
 import json
@@ -8,10 +8,7 @@ import sys
 import tempfile
 
 sys.path.insert(0, os.path.dirname(__file__))
-from importlib import import_module
-
-# Import the script as a module
-spec = import_module('adapt-spec-for-foundry')
+import adapt_spec_for_foundry as spec  # noqa: E402
 
 PASS = 0
 FAIL = 0

--- a/skills/api-integrations/SKILL.md
+++ b/skills/api-integrations/SKILL.md
@@ -62,13 +62,13 @@ For detailed download commands and structural fix patterns, see [references/spec
 
 ```bash
 # Adapt the spec — fixes auth, server URLs, deduplicates params
-python3 /path/to/adapt-spec-for-foundry.py /tmp/VendorApi.yaml
+python3 /path/to/adapt_spec_for_foundry.py /tmp/VendorApi.yaml
 
 # Preview changes without writing
-python3 /path/to/adapt-spec-for-foundry.py /tmp/VendorApi.yaml --dry-run
+python3 /path/to/adapt_spec_for_foundry.py /tmp/VendorApi.yaml --dry-run
 ```
 
-> **Note:** The PreToolUse hook runs this script automatically before `foundry api-integrations create`. Running it explicitly is optional — it lets you see what changed. The script is at the plugin root: `scripts/adapt-spec-for-foundry.py`.
+> **Note:** The PreToolUse hook runs this script automatically before `foundry api-integrations create`. Running it explicitly is optional — it lets you see what changed. The script is at the plugin root: `scripts/adapt_spec_for_foundry.py`.
 
 The script applies fixes derived from 12 production Foundry sample apps:
 - **Swagger 2.0 conversion**: Converts to OpenAPI 3.0 via `swagger2openapi` (npx)
@@ -90,7 +90,7 @@ foundry api-integrations create --name "VendorApi" --description "Vendor API" --
 
 Only add `x-cs-operation-config` if the user's prompt explicitly asks to expose operations to workflows, or a UI extension / workflow in the app needs a specific endpoint. See [Expose Operations to Workflows](#expose-operations-to-workflows) below.
 
-**Safety net**: The PreToolUse hook runs `adapt-spec-for-foundry.py` automatically if you forget step 2. But running it explicitly lets you see what changed before registering.
+**Safety net**: The PreToolUse hook runs `adapt_spec_for_foundry.py` automatically if you forget step 2. But running it explicitly lets you see what changed before registering.
 
 ## Authentication Configuration
 
@@ -220,7 +220,7 @@ json.dump(spec, open(sys.argv[1], 'w'), indent=2)
 - **Writing specs from scratch** when the vendor publishes one. Hand-written specs miss edge cases.
 - **Running spec linters before importing.** Foundry's import handles vendor specs with lint errors. Linting wastes time and tempts trimming.
 - **Trimming vendor specs.** Keep the full spec. Foundry handles large specs and unused operations gracefully.
-- **Skipping `adapt-spec-for-foundry.py`.** The hook runs it automatically, but explicit runs let you verify fixes. The script converts unsupported auth schemes and fixes server URLs that would otherwise block saving in the Foundry console.
+- **Skipping `adapt_spec_for_foundry.py`.** The hook runs it automatically, but explicit runs let you verify fixes. The script converts unsupported auth schemes and fixes server URLs that would otherwise block saving in the Foundry console.
 - **Including `https://` in server URLs** with variables. The Falcon console adds the protocol separately.
 - **Adding `default` to server variables** for dynamic domains. This renders a dropdown instead of a text field.
 - **Splitting domains** into `{subdomain}.vendor.com` instead of `{yourDomain}` for the full domain.

--- a/skills/development-workflow/SKILL.md
+++ b/skills/development-workflow/SKILL.md
@@ -147,7 +147,7 @@ foundry ui navigation add --name "My Page" --path / --ref pages.my-page
 foundry ui extensions create --name "my-ext" --description "desc" --from-template React --sockets "activity.detections.details" --no-prompt
 ```
 
-**Fail fast:** Validate right after API integrations and collections. `foundry apps validate` is a dry-run of deploy validation — it checks specs and schemas in seconds without building artifacts. It does NOT check workflow semantics or app name uniqueness (those are only checked on deploy). Don't validate right before deploy — deploy runs the same validation plus more. Don't manually fix spec issues — improve `adapt-spec-for-foundry.py` instead.
+**Fail fast:** Validate right after API integrations and collections. `foundry apps validate` is a dry-run of deploy validation — it checks specs and schemas in seconds without building artifacts. It does NOT check workflow semantics or app name uniqueness (those are only checked on deploy). Don't validate right before deploy — deploy runs the same validation plus more. Don't manually fix spec issues — improve `adapt_spec_for_foundry.py` instead.
 
 ### Step 6: Write Domain-Specific Content
 


### PR DESCRIPTION
The repo's `.pylintrc` sets `module-naming-style=snake_case`, but two scripts still used dashes: `adapt-spec-for-foundry.py` and `test-adapt-spec.py`. pylint can't enforce the module-name rule on dash-named files (they aren't valid module identifiers), so the violation passed CI unnoticed. #53 added the falconpy `.pylintrc` and the pylint job but did not rename the scripts.

This renames both to snake_case via `git mv` (history preserved):

- `scripts/adapt-spec-for-foundry.py` → `scripts/adapt_spec_for_foundry.py`
- `scripts/test-adapt-spec.py` → `scripts/test_adapt_spec.py`

`test_adapt_spec.py` previously imported the target via `importlib.import_module('adapt-spec-for-foundry')` — a workaround forced by the dash — and now imports the module directly. All references are updated: the PreToolUse hook (`foundry-skill-router.sh`), the CI test step, and the api-integrations and development-workflow skill docs. No script behavior changed.

Verified locally: 30/30 tests pass, pylint 10.00/10, shellcheck clean, 182/182 hook tests pass.

Upgrade impact: users who update the plugin get the new filenames; the old dash-named files are removed by the update (they ship in the same plugin tree as the hook that calls them, so hook and script move together). The only break would be for anyone who invoked the old script path directly in their own tooling — noted in the CHANGELOG under Changed.