### PR TITLE
Split runtime and test dependencies into separate requirements files

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,5 @@
 # Test dependencies for foundry-skills scripts.
-# crowdstrike-falconpy stays unpinned per CrowdStrike guidance (first-party, back-compatible).
-crowdstrike-falconpy
-pyyaml
+# Runtime deps (crowdstrike-falconpy, pyyaml) live in requirements.txt.
+-r requirements.txt
 pytest
 pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+# Runtime dependencies for foundry-skills scripts.
+# crowdstrike-falconpy stays unpinned per CrowdStrike guidance (first-party, back-compatible).
+crowdstrike-falconpy
+pyyaml

--- a/tests/test_adapt_spec.py
+++ b/tests/test_adapt_spec.py
@@ -380,7 +380,7 @@ def test_reads_swagger2_security_definitions():
 def test_load_and_save_yaml_round_trip():
     doc = make_spec()
     with tempfile.NamedTemporaryFile(suffix=".yaml", mode="w", delete=False) as f:
-        import yaml  # provided via requirements-test.txt
+        import yaml  # provided via requirements.txt
 
         yaml.safe_dump(doc, f)
         path = f.name


### PR DESCRIPTION
The scripts the skills execute at runtime (`action_search.py`) import `crowdstrike-falconpy` and `pyyaml`, while `pytest` and `pytest-cov` are only needed to run the test suite. Previously all four lived in `requirements-test.txt`, so a user who only wants to run the skills was pointed at the test file and pulled test tooling they did not need.

This adds a `requirements.txt` with just the runtime dependencies, and has `requirements-test.txt` include it via `-r requirements.txt` plus the test-only packages.

- `requirements.txt` — `crowdstrike-falconpy` (unpinned per CrowdStrike guidance), `pyyaml`
- `requirements-test.txt` — `-r requirements.txt`, `pytest`, `pytest-cov`

CI is unchanged in behavior: it installs `requirements-test.txt`, which now transitively installs the runtime deps. All 48 unit tests pass locally against the split.