### PR TITLE
Ignore unapproved actions/setup-python versions in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,5 @@ updates:
         versions: [">=6.0.3"]
       - dependency-name: "actions/setup-node"
         versions: [">=6.3.0"]
+      - dependency-name: "actions/setup-python"
+        versions: [">=6.3.0"]


### PR DESCRIPTION
`actions/setup-python@v6.3.0` is not on the CrowdStrike org's GitHub Actions allowlist, so Dependabot PR #69 couldn't run CI at all (no checks fired). Adds an ignore rule to `.github/dependabot.yml` matching the pattern already in place for `actions/checkout` and `actions/setup-node`.

This prevents Dependabot from repeatedly opening PRs for action versions the org hasn't approved yet. When the version is eventually allowlisted, remove the ignore entry and Dependabot will propose the bump again.