### PR TITLE
Add function logs to testing-patterns reference table entry

### DIFF
--- a/skills/functions-development/SKILL.md
+++ b/skills/functions-development/SKILL.md
@@ -55,7 +55,7 @@ This skill is split across multiple files. Consult these for full examples:
 |------|-----------|
 | Python handler, collection CRUD, error class, batch processing, LogScale ingestion | [references/python-patterns.md](references/python-patterns.md) |
 | Go FDK handler, Falcon client auth, collection CRUD, alerts handler | [references/go-patterns.md](references/go-patterns.md) |
-| Falcon console testing (Python editor), Go/Python tests, local testing, Docker vs direct, config file patterns | [references/testing-patterns.md](references/testing-patterns.md) |
+| Falcon console testing (Python editor), function logs (viewing logs in UI and Advanced Event Search), Go/Python tests, local testing, Docker vs direct, config file patterns | [references/testing-patterns.md](references/testing-patterns.md) |
 
 ## Resource Limits
 


### PR DESCRIPTION
The functions-development skill already documents how to view function logs (in `testing-patterns.md` lines 69-73 and in the `python-functions.md` use case), but the reference table in SKILL.md didn't mention "logs" anywhere. This caused Claude to skip reading the reference file when asked about function logs and conclude the skill couldn't answer the question.

Adds "function logs (viewing logs in UI and Advanced Event Search)" to the testing-patterns.md row in the reference table so the information gets surfaced properly.