### PR TITLE
Document collection description validation constraints

### DIFF
--- a/skills/collections-development/SKILL.md
+++ b/skills/collections-development/SKILL.md
@@ -30,6 +30,15 @@ Falcon Foundry Collections are NoSQL document stores with JSON Schema validation
 | Special characters | Only underscores (`_`) allowed — no hyphens, spaces, or other chars |
 | Case | Case-sensitive |
 
+## Collection Description Constraints
+
+| Constraint | Rule |
+|-----------|------|
+| Length | 3-500 characters |
+| Start | Must begin with an alphanumeric character |
+| Allowed characters | Letters, numbers, spaces, dashes, periods, parentheses, and underscores only |
+| Not allowed | Commas, colons, semicolons, quotes, slashes, or other special characters |
+
 ## JSON Schema Requirements
 
 - **JSON Schema draft 7 only** — newer drafts (`draft/2020-12`, `draft/2019-09`) fail validation


### PR DESCRIPTION
The Foundry platform enforces character restrictions on collection descriptions that were not documented in the skills plugin. The agent consistently generates descriptions with commas (e.g., "Tracks phishing campaigns with sender domains, targets, detection rates, and linked IOCs") which fail validation at deploy time.

This adds a constraint table to `skills/collections-development/SKILL.md` documenting the allowed characters: letters, numbers, spaces, dashes, periods, parentheses, and underscores only. No commas, colons, semicolons, quotes, or slashes.

Validated against the `phishing-campaign-collection` eval which was failing 0/5 trials due to this issue.