### PR TITLE
Add LogScale query recipe, function schema requirements, and workflow deletion warning

### DIFF
--- a/skills/functions-development/SKILL.md
+++ b/skills/functions-development/SKILL.md
@@ -87,6 +87,62 @@ foundry functions create \
   --no-prompt
 ```
 
+## Function I/O Schemas — Required at Creation Time
+
+> **⚠️ CRITICAL:** Functions that will be called from workflows MUST define `input_schema` and `output_schema` in the manifest at creation time. Functions created without an output schema produce **no visible output** in Fusion workflow actions — the action completes but downstream steps cannot reference any data from it.
+
+### Why This Matters
+
+When the CLI creates a function with `workflow_integration`, the platform registers the function's schema with the workflow engine. If `output_schema` is missing:
+- The corresponding Fusion action shows zero output fields
+- Workflow variable references like `${data['my_function.output.field']}` resolve to nothing
+- The workflow appears to work but produces empty results
+
+### Manifest Example
+
+```yaml
+functions:
+  - name: query-stats
+    description: "Query execution statistics"
+    language: python
+    path: "functions/query-stats"
+    handlers:
+      - name: query
+        method: POST
+        path: "/api/query"
+    workflow_integration:
+      id: <generated-after-first-deploy>
+      input_schema:
+        properties:
+          time_range:
+            type: string
+            description: "Time range for the query (e.g., 24h, 7d)"
+        required:
+          - time_range
+        type: object
+      output_schema:
+        properties:
+          results:
+            type: array
+            items:
+              type: object
+          total_count:
+            type: integer
+        type: object
+```
+
+### Fixing a Function Missing Schemas
+
+If a function was deployed without schemas, **adding them to the manifest and redeploying does NOT bind them.** The I/O schema binding happens only at function creation time via the `--input-schema`/`--output-schema` CLI flags.
+
+To fix this:
+1. Delete the function from the manifest
+2. Recreate it with schemas: `foundry functions create --name "my-func" --input-schema request_schema.json --output-schema response_schema.json --wf-expose --no-prompt`
+3. Update any workflow YAML that references the function (the `workflow_integration.id` will change)
+4. Redeploy the app
+
+**Warning:** Deleting and recreating a function changes its workflow integration ID. You MUST update workflow YAML references. But do NOT delete and recreate the *workflows themselves* to fix this — that causes cascading "duplicate name" errors (see the workflows-development skill for details). Instead, edit the workflow YAML in place to reference the new function ID, then redeploy.
+
 ## Language Comparison
 
 | Feature | Go | Python |

--- a/skills/functions-development/SKILL.md
+++ b/skills/functions-development/SKILL.md
@@ -89,59 +89,66 @@ foundry functions create \
 
 ## Function I/O Schemas — Required at Creation Time
 
-> **⚠️ CRITICAL:** Functions that will be called from workflows MUST define `input_schema` and `output_schema` in the manifest at creation time. Functions created without an output schema produce **no visible output** in Fusion workflow actions — the action completes but downstream steps cannot reference any data from it.
+> **⚠️ CRITICAL:** Functions called from workflows MUST be created with `--input-schema` and `--output-schema`. Schemas bind only at creation time. A function created without an output schema produces **no visible output** in its Fusion action — the action completes, but downstream steps cannot reference any data from it.
 
 ### Why This Matters
 
-When the CLI creates a function with `workflow_integration`, the platform registers the function's schema with the workflow engine. If `output_schema` is missing:
-- The corresponding Fusion action shows zero output fields
-- Workflow variable references like `${data['my_function.output.field']}` resolve to nothing
-- The workflow appears to work but produces empty results
+The platform registers a handler's schemas with the workflow engine when the function is created. Without a response schema:
+- The Fusion action shows zero output fields
+- Workflow references like `${data['my_function.output.field']}` resolve to nothing
+- The workflow appears to run but produces empty results
 
-### Manifest Example
+Passing `--wf-expose` alone is not enough. It creates the workflow binding; the schema fields are still written as `null`.
+
+### Create the Function with Schemas
+
+Write the two JSON Schema files first, then pass them to `foundry functions create`. The CLI copies them into the function directory and records them in the manifest:
+
+```bash
+foundry functions create \
+  --name "query-stats" \
+  --language python \
+  --description "Query execution statistics" \
+  --handler-name query \
+  --handler-method POST \
+  --handler-path /api/query \
+  --input-schema request_schema.json \
+  --output-schema response_schema.json \
+  --wf-expose \
+  --no-prompt
+```
+
+The resulting manifest entry references the schemas **by filename on the handler** — not as inline JSON, and not under `workflow_integration`:
 
 ```yaml
 functions:
-  - name: query-stats
-    description: "Query execution statistics"
-    language: python
-    path: "functions/query-stats"
-    handlers:
-      - name: query
-        method: POST
-        path: "/api/query"
-    workflow_integration:
-      id: <generated-after-first-deploy>
-      input_schema:
-        properties:
-          time_range:
-            type: string
-            description: "Time range for the query (e.g., 24h, 7d)"
-        required:
-          - time_range
-        type: object
-      output_schema:
-        properties:
-          results:
-            type: array
-            items:
-              type: object
-          total_count:
-            type: integer
-        type: object
+    - name: query-stats
+      path: functions/query-stats
+      handlers:
+        - name: query
+          method: POST
+          api_path: /api/query
+          request_schema: request_schema.json
+          response_schema: response_schema.json
+          workflow_integration:
+            id: <generated>
+            disruptive: false
+            system_action: true
+      language: python
 ```
+
+Without `--input-schema`/`--output-schema`, both fields are written as `null` — including when `--wf-expose` is set. `--wf-expose` creates the workflow binding but does NOT generate schemas.
 
 ### Fixing a Function Missing Schemas
 
-If a function was deployed without schemas, **adding them to the manifest and redeploying does NOT bind them.** The I/O schema binding happens only at function creation time via the `--input-schema`/`--output-schema` CLI flags.
+Adding `request_schema`/`response_schema` to the manifest by hand and redeploying does NOT bind them. The binding happens only at creation time via the CLI flags. To fix a function that was created without them:
 
-To fix this:
-1. Delete the function from the manifest
-2. Recreate it with schemas: `foundry functions create --name "my-func" --input-schema request_schema.json --output-schema response_schema.json --wf-expose --no-prompt`
-3. Update any workflow YAML that references the function (the `workflow_integration.id` will change)
-4. Redeploy the app
+1. Remove the function's entry from `manifest.yml` and delete its directory
+2. Recreate it with `--input-schema`/`--output-schema` as shown above
+3. Update any workflow YAML referencing it — the `workflow_integration.id` changes
+4. Redeploy
 
-**Warning:** Deleting and recreating a function changes its workflow integration ID. You MUST update workflow YAML references. But do NOT delete and recreate the *workflows themselves* to fix this — that causes cascading "duplicate name" errors (see the workflows-development skill for details). Instead, edit the workflow YAML in place to reference the new function ID, then redeploy.
+**Warning:** Step 3 matters. Recreating the function gives it a new workflow integration ID, so existing workflow YAML points at nothing. Edit the workflow YAML in place to reference the new ID — do NOT delete and recreate the *workflows* to force a refresh, which triggers `409 name must be unique for an app` and can corrupt the app's dependency graph. See [workflows-development](../workflows-development/SKILL.md) for details.
 
 ## Language Comparison
 

--- a/skills/functions-falcon-api/SKILL.md
+++ b/skills/functions-falcon-api/SKILL.md
@@ -208,6 +208,109 @@ def enrich_host_context(request: Request, config, logger) -> Response:
     return Response(body={"host": host, "detections": detections, "alerts": alerts}, code=200)
 ```
 
+## LogScale / NG-SIEM Queries from Functions
+
+When you need to **query** LogScale data (e.g., workflow execution stats from the "fusion" repo, detection telemetry, custom ingested events), use the `NGSIEM` class. This is distinct from **ingestion** (covered in functions-development).
+
+> **⚠️ Class Disambiguation:**
+> - `NGSIEM` — Use for **querying** (async search jobs) and file uploads (lookup files, CSV imports). This is the query interface.
+> - `FoundryLogScale` — Use only for **ingestion** (`ingest_data`). Despite the name suggesting broad LogScale functionality, it does NOT have the search methods.
+
+### Query Pattern (Python)
+
+```python
+import os
+import time
+from logging import Logger
+from typing import Any, Dict, Union
+from crowdstrike.foundry.function import Function, Request, Response
+from falconpy import NGSIEM
+
+func = Function.instance()
+
+REPO = os.environ.get("FH_LOGSCALE_REPO", "search-all")
+
+
+def run_logscale_query(ngsiem, query_string, start, end, logger, max_wait=40):
+    """Execute a CQL query as an async search job and return result rows.
+
+    ``start`` / ``end`` accept Humio relative strings ("24h", "7d", "30d",
+    "now") or epoch-millisecond integers.
+    """
+    body = {"queryString": query_string, "start": start, "end": end, "isLive": False}
+    started = ngsiem.start_search(repository=REPO, body=body)
+
+    if not isinstance(started, dict) or started.get("status_code", 500) >= 300:
+        logger.error(f"start_search failed: {started}")
+        return None
+
+    job_id = (started.get("body") or {}).get("id")
+    if not job_id:
+        logger.error(f"start_search returned no job id: {started.get('body')}")
+        return None
+
+    # Poll until done
+    waited = 0.0
+    poll_interval = 1.5
+    while waited < max_wait:
+        time.sleep(poll_interval)
+        waited += poll_interval
+        status = ngsiem.get_search_status(repository=REPO, id=job_id)
+        if not isinstance(status, dict) or status.get("status_code", 500) >= 300:
+            logger.error(f"get_search_status failed: {status}")
+            return None
+        sbody = status.get("body") or {}
+        if sbody.get("done"):
+            return sbody.get("events", []) or []
+
+    logger.warning(f"query timed out after {max_wait}s: {query_string}")
+    return None
+
+
+@func.handler(method='POST', path='/api/query')
+def handle_query(request: Request, config: Union[Dict[str, Any], None], logger: Logger) -> Response:
+    ngsiem = NGSIEM()  # Zero-arg auth — automatic in Foundry
+
+    query = request.body.get("query", "")
+    start = request.body.get("start", "24h")
+    end = request.body.get("end", "now")
+
+    events = run_logscale_query(ngsiem, query, start, end, logger)
+    if events is None:
+        return Response(body={"error": "LogScale query failed"}, code=500)
+
+    return Response(body={"results": events, "count": len(events)}, code=200)
+
+if __name__ == '__main__':
+    func.run()
+```
+
+### The "search-all" Repository Gotcha
+
+**CRITICAL:** Always pass `repository="search-all"` when querying from Foundry functions. Passing a specific repository name (e.g., `"fusion"`, `"main"`) causes **403 Forbidden** errors at runtime (`"scope not permitted"`), even if the repository exists and the app has `humio-auth-proxy` scopes granted.
+
+The NG-SIEM queryjobs API is addressed by **searchable view**, not by raw repo name. Use `search-all` as the repository and add `#repo=fusion` (or whichever repo you need) as a filter prefix in your query string:
+
+```python
+# Filter to a specific repo within the query itself
+query = "#repo=fusion | execution_log_type=summary | execution_log_subtype=end | groupby([status], function=count(execution_id, distinct=true))"
+events = run_logscale_query(ngsiem, query, "24h", "now", logger)
+```
+
+### Required OAuth Scopes
+
+```yaml
+# manifest.yml
+auth:
+    scopes:
+        - humio-auth-proxy:read     # Required for queries
+        - humio-auth-proxy:write    # Required only if also uploading lookup files
+```
+
+### Reference
+
+- [Exporting Falcon Next-Gen SIEM Query Results to CSV with Falcon Foundry](https://www.crowdstrike.com/tech-hub/ng-siem/exporting-falcon-next-gen-siem-query-results-to-csv-with-falcon-foundry/) — Complete async query pattern with CSV export
+
 ## The 207 Multi-Status Gotcha
 
 CrowdStrike APIs may return `207 Multi-Status` responses that look successful but contain embedded errors. Check the errors array:
@@ -288,6 +391,7 @@ Each row maps a FalconPy method actually called in a sample function to the scop
 | `IdentityProtection` | `graphql`, `query_sensors`, `get_sensor_details` | `identity-graphql:write`, `identity-entities:read` | foundry-sample-idp-notifications |
 | `IdentityProtection` | `query_policy_rules`, `get_policy_rules`, `delete_policy_rules` | `identity-policy-rules:read`, `identity-policy-rules:write` | foundry-sample-servicenow-idp |
 | `NGSIEM` | `upload_file` | `humio-auth-proxy:write` | foundry-sample-ngsiem-importer |
+| `NGSIEM` | `start_search`, `get_search_status` | `humio-auth-proxy:read` | Fusion Health Insights app (see LogScale Queries section) |
 | `FoundryLogScale` | `ingest_data` | `app-logs:read`, `app-logs:write` | foundry-sample-logscale |
 | `FirewallManagement` | `create_rule_group`, `query_events`, `get_events` | `firewall-management:read`, `firewall-management:write` | foundry-sample-category-blocking |
 | `HostGroup` | `query_host_groups`, `get_host_groups` | `host-group:read`, `host-group:write` | foundry-sample-category-blocking |

--- a/skills/functions-falcon-api/SKILL.md
+++ b/skills/functions-falcon-api/SKILL.md
@@ -219,7 +219,6 @@ When you need to **query** LogScale data (e.g., workflow execution stats from th
 ### Query Pattern (Python)
 
 ```python
-import os
 import time
 from logging import Logger
 from typing import Any, Dict, Union
@@ -228,7 +227,8 @@ from falconpy import NGSIEM
 
 func = Function.instance()
 
-REPO = os.environ.get("FH_LOGSCALE_REPO", "search-all")
+# Always "search-all" — see the gotcha below. Scope to a repo in the query, not here.
+REPO = "search-all"
 
 
 def run_logscale_query(ngsiem, query_string, start, end, logger, max_wait=40):
@@ -309,7 +309,7 @@ auth:
 
 ### Reference
 
-- [Exporting Falcon Next-Gen SIEM Query Results to CSV with Falcon Foundry](https://www.crowdstrike.com/tech-hub/ng-siem/exporting-falcon-next-gen-siem-query-results-to-csv-with-falcon-foundry/) — Complete async query pattern with CSV export
+- [Exporting Falcon Next-Gen SIEM Query Results to CSV with Falcon Foundry](https://www.crowdstrike.com/tech-hub/ng-siem/exporting-falcon-next-gen-siem-query-results-to-csv-with-falcon-foundry/) — background on async LogScale querying from Foundry, plus CSV export. Note that this post reaches for `FoundryLogScale` with `mode="async"`; the `NGSIEM` pattern above is what has been verified end-to-end against the queryjobs API in a deployed app. Use the pattern above, and treat the post as context for the surrounding workflow (time ranges, result handling, export).
 
 ## The 207 Multi-Status Gotcha
 
@@ -391,7 +391,7 @@ Each row maps a FalconPy method actually called in a sample function to the scop
 | `IdentityProtection` | `graphql`, `query_sensors`, `get_sensor_details` | `identity-graphql:write`, `identity-entities:read` | foundry-sample-idp-notifications |
 | `IdentityProtection` | `query_policy_rules`, `get_policy_rules`, `delete_policy_rules` | `identity-policy-rules:read`, `identity-policy-rules:write` | foundry-sample-servicenow-idp |
 | `NGSIEM` | `upload_file` | `humio-auth-proxy:write` | foundry-sample-ngsiem-importer |
-| `NGSIEM` | `start_search`, `get_search_status` | `humio-auth-proxy:read` | Fusion Health Insights app (see LogScale Queries section) |
+| `NGSIEM` | `start_search`, `get_search_status` | `humio-auth-proxy:read` | Verified against FalconPy source; see LogScale Queries section |
 | `FoundryLogScale` | `ingest_data` | `app-logs:read`, `app-logs:write` | foundry-sample-logscale |
 | `FirewallManagement` | `create_rule_group`, `query_events`, `get_events` | `firewall-management:read`, `firewall-management:write` | foundry-sample-category-blocking |
 | `HostGroup` | `query_host_groups`, `get_host_groups` | `host-group:read`, `host-group:write` | foundry-sample-category-blocking |

--- a/skills/workflows-development/SKILL.md
+++ b/skills/workflows-development/SKILL.md
@@ -150,9 +150,9 @@ For full RTR multi-host orchestration and investigation pipeline examples, see [
 
 ## Calling Functions from Workflows
 
-Functions referenced in workflow actions (via `id: functions.{name}.{handler}`) must have `workflow_integration` configured in the manifest. The `foundry functions create` CLI command handles this automatically when you specify the appropriate flags. Do not manually edit `manifest.yml` to add `workflow_integration` — use the CLI.
+Functions referenced in workflow actions (via `id: functions.{name}.{handler}`) must have `workflow_integration` in the manifest. This binds only at creation time, via `foundry functions create --wf-expose` (plus `--input-schema`/`--output-schema`) — hand-editing `manifest.yml` does not work.
 
-If a function was created without workflow integration and you later need it callable from workflows, add the `workflow_integration` block to the function's manifest entry and redeploy. Do NOT delete and recreate the function — see the warning below.
+If a function was created without it, recreate the function. That changes its `workflow_integration.id`, so update the `id: functions.{name}.{handler}` reference in your workflow YAML in place. Do NOT delete and recreate the workflow itself — see the warning below.
 
 **Deploy error if missing:**
 ```

--- a/skills/workflows-development/SKILL.md
+++ b/skills/workflows-development/SKILL.md
@@ -152,7 +152,7 @@ For full RTR multi-host orchestration and investigation pipeline examples, see [
 
 Functions referenced in workflow actions (via `id: functions.{name}.{handler}`) must have `workflow_integration` configured in the manifest. The `foundry functions create` CLI command handles this automatically when you specify the appropriate flags. Do not manually edit `manifest.yml` to add `workflow_integration` — use the CLI.
 
-If a function was created without workflow integration and you later need it callable from workflows, delete and re-create it with the appropriate flags.
+If a function was created without workflow integration and you later need it callable from workflows, add the `workflow_integration` block to the function's manifest entry and redeploy. Do NOT delete and recreate the function — see the warning below.
 
 **Deploy error if missing:**
 ```
@@ -341,6 +341,24 @@ See [pagination-patterns](references/pagination-patterns.md#the-0-gotcha) for th
 ## Workflow Name Uniqueness
 
 Workflow names must be unique across all apps in the same tenant. If two apps deploy workflows with the same name, the second deploy fails silently or produces an "Unknown error." Use app-specific prefixes when the workflow name is generic.
+
+## NEVER Delete and Recreate Workflows
+
+> **⚠️ DANGER:** Deleting a workflow and recreating it with the same name causes cascading failures that often require deleting the entire app to recover.
+
+**What happens when you delete + recreate:**
+1. Removing a workflow from the manifest does NOT delete its server-side artifact
+2. Creating a new workflow with the same name triggers `409 name must be unique for an app`
+3. A once-failed workflow artifact taints the app's dependency graph, producing `400 dependent artifact failed` on all subsequent deploys
+4. Recovery typically requires: backup function code → delete the entire app → create a fresh app → restore code
+
+**Instead, update in place:**
+- To fix workflow YAML errors: edit the YAML file and redeploy
+- To change a workflow's trigger type: edit the `trigger:` block in the YAML and redeploy
+- To re-bind a workflow to a recreated function: update the `id: functions.{name}.{handler}` reference in the workflow YAML, then redeploy
+- To add/change function I/O schemas: recreate the function (not the workflow), then update the workflow's function reference
+
+**The only safe deletion** is removing a workflow you genuinely no longer need (and won't recreate with the same name). Even then, ensure no other workflows reference it via sub-workflow calls before deleting.
 
 ## Workflow Sharing
 

--- a/skills/workflows-development/SKILL.md
+++ b/skills/workflows-development/SKILL.md
@@ -344,21 +344,11 @@ Workflow names must be unique across all apps in the same tenant. If two apps de
 
 ## NEVER Delete and Recreate Workflows
 
-> **⚠️ DANGER:** Deleting a workflow and recreating it with the same name causes cascading failures that often require deleting the entire app to recover.
+> **⚠️ DANGER:** Deleting a workflow and recreating it with the same name causes cascading failures requiring a fresh app to recover.
 
-**What happens when you delete + recreate:**
-1. Removing a workflow from the manifest does NOT delete its server-side artifact
-2. Creating a new workflow with the same name triggers `409 name must be unique for an app`
-3. A once-failed workflow artifact taints the app's dependency graph, producing `400 dependent artifact failed` on all subsequent deploys
-4. Recovery typically requires: backup function code → delete the entire app → create a fresh app → restore code
+Removing a workflow from the manifest does NOT delete its server-side artifact. Recreating with the same name → `409 name must be unique for an app`. A once-failed artifact taints the dependency graph (`400 dependent artifact failed`), blocking all further deploys.
 
-**Instead, update in place:**
-- To fix workflow YAML errors: edit the YAML file and redeploy
-- To change a workflow's trigger type: edit the `trigger:` block in the YAML and redeploy
-- To re-bind a workflow to a recreated function: update the `id: functions.{name}.{handler}` reference in the workflow YAML, then redeploy
-- To add/change function I/O schemas: recreate the function (not the workflow), then update the workflow's function reference
-
-**The only safe deletion** is removing a workflow you genuinely no longer need (and won't recreate with the same name). Even then, ensure no other workflows reference it via sub-workflow calls before deleting.
+**Instead, update in place** — edit the workflow YAML and redeploy. To re-bind a workflow to a recreated function, update the `id: functions.{name}.{handler}` reference in the YAML. Only delete a workflow if you genuinely no longer need it and won't recreate it with the same name.
 
 ## Workflow Sharing
 
@@ -372,7 +362,7 @@ workflows:
       system_action: false   # false = available as a Fusion SOAR response action; true = internal app use only
 ```
 
-> **⚠️ SOAR action visibility:** Set `system_action: false` when the workflow should appear as a response action in Falcon Fusion SOAR (analysts can trigger it from detections, incidents, or other workflows). Set `system_action: true` when the workflow is only used internally by the app (e.g., scheduled data sync, internal helper). If the user asks for a "SOAR action" or "response action", always use `false`.
+> **⚠️ SOAR action visibility:** `system_action: false` = workflow appears as a Fusion SOAR response action (analysts trigger from detections/incidents). `system_action: true` = internal app use only (scheduled sync, helpers). If the user asks for a "SOAR action" or "response action", use `false`.
 
 ## Error Handling
 
@@ -380,15 +370,7 @@ Foundry workflows handle errors through conditional routing and action-level fla
 
 ## Testing
 
-```bash
-foundry workflows triggers view --mock --no-prompt       # Example mock trigger
-foundry workflows actions view --mock --no-prompt        # Example mock action
-foundry workflows executions validate --mocks mymocks.json              # Validate mocks
-foundry workflows executions start --definition my-workflow --mocks mymocks.json  # Run with mocks
-foundry workflows executions view <execution_id>                        # View results
-```
-
-Use `foundry apps validate --no-prompt` to validate the manifest and schemas without deploying. Workflow YAML semantics are still validated server-side on deploy.
+See [references/advanced-patterns.md](references/advanced-patterns.md) for workflow testing commands (mock triggers, mock actions, execution validation, and `foundry apps validate`).
 
 ## Reading Guide
 
@@ -402,10 +384,7 @@ Use `foundry apps validate --no-prompt` to validate the manifest and schemas wit
 | CEL extension functions reference | [Data Transformation Functions](https://docs.crowdstrike.com/r/k223d842) |
 | Pagination strategies | [references/pagination-patterns.md](references/pagination-patterns.md) |
 | HTTP Actions (call REST APIs without an app) | [references/http-actions.md](references/http-actions.md) |
-| HTTP Request actions, testing, validation | [references/advanced-patterns.md](references/advanced-patterns.md) |
-| Error handling (fail_fast, partial execution, routing) | [references/advanced-patterns.md](references/advanced-patterns.md) |
-| Parameterized fields versioning | [references/advanced-patterns.md](references/advanced-patterns.md) |
-| Counter-rationalizations and red flags | [references/advanced-patterns.md](references/advanced-patterns.md) |
+| Error handling, HTTP Request actions, parameterized fields, counter-rationalizations | [references/advanced-patterns.md](references/advanced-patterns.md) |
 
 ## Use Cases
 

--- a/skills/workflows-development/references/advanced-patterns.md
+++ b/skills/workflows-development/references/advanced-patterns.md
@@ -2,6 +2,18 @@
 
 > Parent skill: [workflows-development](../SKILL.md)
 
+## Testing Workflows
+
+```bash
+foundry workflows triggers view --mock --no-prompt       # Example mock trigger
+foundry workflows actions view --mock --no-prompt        # Example mock action
+foundry workflows executions validate --mocks mymocks.json              # Validate mocks
+foundry workflows executions start --definition my-workflow --mocks mymocks.json  # Run with mocks
+foundry workflows executions view <execution_id>                        # View results
+```
+
+Use `foundry apps validate --no-prompt` to validate the manifest and schemas without deploying. Workflow YAML semantics are still validated server-side on deploy.
+
 ## Parameterized Fields Versioning Impact
 
 Workflow templates support parameterized fields — values that users configure when provisioning a workflow from the template. Check the "Parameterized" checkbox in the App Builder to mark fields as configurable.

--- a/tests/test_skill_content.py
+++ b/tests/test_skill_content.py
@@ -1,0 +1,153 @@
+"""Content evals for Foundry skill documentation.
+
+These tests verify that critical guidance is present in skill files —
+acting as regression guards against accidental removal of hard-won lessons.
+No network or credentials needed; tests read skill files directly.
+"""
+
+import os
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _read_skill(relative_path: str) -> str:
+    """Read a skill file and return its content as a string."""
+    path = os.path.join(_ROOT, relative_path)
+    with open(path) as f:
+        return f.read()
+
+
+# ── LogScale/NGSIEM query recipe (functions-falcon-api) ─────────────────────
+
+
+class TestNGSIEMQueryRecipe:
+    """Verify the NGSIEM query recipe covers Jeevan's Problem 1 and 2."""
+
+    SKILL = "skills/functions-falcon-api/SKILL.md"
+
+    def test_class_disambiguation_present(self):
+        """Must clarify when to use NGSIEM vs FoundryLogScale."""
+        content = _read_skill(self.SKILL)
+        assert "NGSIEM" in content
+        assert "FoundryLogScale" in content
+        # Must explicitly state NGSIEM is for querying
+        assert "querying" in content.lower() or "query" in content.lower()
+
+    def test_search_all_repository_documented(self):
+        """Must document 'search-all' as the required repository value."""
+        content = _read_skill(self.SKILL)
+        assert "search-all" in content
+        # Must explain that specific repo names cause 403
+        assert "403" in content
+
+    def test_start_search_method_shown(self):
+        """Must show the NGSIEM start_search method."""
+        content = _read_skill(self.SKILL)
+        assert "start_search" in content
+        assert "get_search_status" in content
+        # Must use the NGSIEM class, not FoundryLogScale, for searching
+        assert "ngsiem.start_search" in content.lower() or \
+               "NGSIEM()" in content
+
+    def test_query_scope_documented(self):
+        """Must document humio-auth-proxy:read for queries."""
+        content = _read_skill(self.SKILL)
+        assert "humio-auth-proxy:read" in content
+
+    def test_repo_filter_in_query_string(self):
+        """Must show how to filter to a specific repo within the query string."""
+        content = _read_skill(self.SKILL)
+        assert "#repo=" in content
+
+    def test_blog_reference_included(self):
+        """Must link to the Tech Hub blog post as reference."""
+        content = _read_skill(self.SKILL)
+        assert "exporting-falcon-next-gen-siem-query-results-to-csv" in content
+
+
+# ── Function I/O schema requirements (functions-development) ────────────────
+
+
+class TestFunctionSchemaRequirements:
+    """Verify function schema guidance covers Jeevan's Problem 3."""
+
+    SKILL = "skills/functions-development/SKILL.md"
+
+    def test_output_schema_requirement_documented(self):
+        """Must state that output_schema is required at creation time."""
+        content = _read_skill(self.SKILL)
+        assert "output_schema" in content
+        # Must be framed as a requirement, not optional
+        assert "MUST" in content or "Required" in content or "CRITICAL" in content
+
+    def test_missing_schema_consequence_explained(self):
+        """Must explain what happens without output schema."""
+        content = _read_skill(self.SKILL)
+        # Must mention that actions show no output
+        assert "no visible output" in content or "zero output" in content
+
+    def test_schema_manifest_example_provided(self):
+        """Must show a manifest.yml example with workflow_integration schemas."""
+        content = _read_skill(self.SKILL)
+        assert "workflow_integration" in content
+        assert "input_schema" in content
+        assert "output_schema" in content
+
+    def test_does_not_recommend_manifest_edit_to_fix_schema(self):
+        """Must NOT claim that editing manifest and redeploying binds schemas."""
+        content = _read_skill(self.SKILL)
+        # Find the schema section and verify it explains schemas can't be added after creation
+        schema_section_start = content.find("Function I/O Schemas")
+        assert schema_section_start != -1
+        schema_section = content[schema_section_start:schema_section_start + 3000]
+        assert "does NOT bind" in schema_section or "does not bind" in schema_section.lower()
+
+    def test_creation_time_requirement_emphasized(self):
+        """Must state schemas are bound at creation time via CLI flags."""
+        content = _read_skill(self.SKILL)
+        assert "--input-schema" in content or "--output-schema" in content
+
+
+# ── Workflow deletion warning (workflows-development) ───────────────────────
+
+
+class TestWorkflowDeletionWarning:
+    """Verify workflow deletion danger covers Jeevan's Problem 4."""
+
+    SKILL = "skills/workflows-development/SKILL.md"
+
+    def test_deletion_warning_present(self):
+        """Must have a dedicated warning about workflow deletion dangers."""
+        content = _read_skill(self.SKILL)
+        assert "NEVER Delete and Recreate Workflows" in content or \
+               "NEVER delete and recreate" in content.lower()
+
+    def test_duplicate_name_trap_documented(self):
+        """Must explain the 'duplicate name' / 409 error that results."""
+        content = _read_skill(self.SKILL)
+        assert "409" in content or "duplicate name" in content.lower() or \
+               "name must be unique" in content
+
+    def test_recovery_cost_explained(self):
+        """Must explain that recovery often requires deleting the entire app."""
+        content = _read_skill(self.SKILL)
+        assert "delete the entire app" in content or \
+               "deleting the entire app" in content or \
+               "fresh app" in content
+
+    def test_dependent_artifact_error_documented(self):
+        """Must document the cascading 'dependent artifact failed' error."""
+        content = _read_skill(self.SKILL)
+        assert "dependent artifact" in content
+
+    def test_alternatives_provided(self):
+        """Must provide safe alternatives (update in place, redeploy)."""
+        content = _read_skill(self.SKILL)
+        assert "update in place" in content.lower() or "edit" in content.lower()
+        assert "redeploy" in content or "deploy" in content
+
+    def test_old_delete_advice_removed(self):
+        """Must NOT advise 'delete and re-create' as a fix for missing workflow_integration."""
+        content = _read_skill(self.SKILL)
+        # The old advice was exactly this sentence:
+        assert "delete and re-create it with the appropriate flags" not in content

--- a/tests/test_skill_content.py
+++ b/tests/test_skill_content.py
@@ -26,12 +26,12 @@ class TestNGSIEMQueryRecipe:
     SKILL = "skills/functions-falcon-api/SKILL.md"
 
     def test_class_disambiguation_present(self):
-        """Must clarify when to use NGSIEM vs FoundryLogScale."""
+        """Must state which class to use for querying vs ingestion."""
         content = _read_skill(self.SKILL)
-        assert "NGSIEM" in content
-        assert "FoundryLogScale" in content
-        # Must explicitly state NGSIEM is for querying
-        assert "querying" in content.lower() or "query" in content.lower()
+        # Anchor on the disambiguation callout, not the bare class names —
+        # both appear in the scope table on main.
+        assert "Class Disambiguation" in content
+        assert "ingest_data" in content, "must name FoundryLogScale's ingestion method"
 
     def test_search_all_repository_documented(self):
         """Must document 'search-all' as the required repository value."""
@@ -74,38 +74,45 @@ class TestFunctionSchemaRequirements:
     SKILL = "skills/functions-development/SKILL.md"
 
     def test_output_schema_requirement_documented(self):
-        """Must state that output_schema is required at creation time."""
+        """Must state output schema is required at creation time."""
         content = _read_skill(self.SKILL)
-        assert "output_schema" in content
-        # Must be framed as a requirement, not optional
-        assert "MUST" in content or "Required" in content or "CRITICAL" in content
+        assert "Function I/O Schemas" in content
+        assert "--output-schema" in content
 
     def test_missing_schema_consequence_explained(self):
-        """Must explain what happens without output schema."""
+        """Must explain what happens without an output schema."""
         content = _read_skill(self.SKILL)
-        # Must mention that actions show no output
         assert "no visible output" in content or "zero output" in content
 
-    def test_schema_manifest_example_provided(self):
-        """Must show a manifest.yml example with workflow_integration schemas."""
-        content = _read_skill(self.SKILL)
-        assert "workflow_integration" in content
-        assert "input_schema" in content
-        assert "output_schema" in content
+    def test_uses_real_manifest_field_names(self):
+        """Must use the field names the CLI actually writes.
 
-    def test_does_not_recommend_manifest_edit_to_fix_schema(self):
-        """Must NOT claim that editing manifest and redeploying binds schemas."""
+        The CLI records schemas as request_schema/response_schema on the
+        handler. An earlier draft used input_schema/output_schema nested under
+        workflow_integration, which does not exist in a real manifest.
+        """
         content = _read_skill(self.SKILL)
-        # Find the schema section and verify it explains schemas can't be added after creation
+        assert "request_schema" in content
+        assert "response_schema" in content
+
+    def test_wf_expose_alone_is_insufficient(self):
+        """Must warn that --wf-expose does not generate schemas."""
+        content = _read_skill(self.SKILL)
+        assert "--wf-expose" in content
+        assert "null" in content, "must state schema fields are null without the flags"
+
+    def test_does_not_claim_manifest_edit_binds_schemas(self):
+        """Must state that hand-editing the manifest does not bind schemas."""
+        content = _read_skill(self.SKILL)
         schema_section_start = content.find("Function I/O Schemas")
         assert schema_section_start != -1
         schema_section = content[schema_section_start:schema_section_start + 3000]
         assert "does NOT bind" in schema_section or "does not bind" in schema_section.lower()
 
     def test_creation_time_requirement_emphasized(self):
-        """Must state schemas are bound at creation time via CLI flags."""
+        """Must show both CLI schema flags."""
         content = _read_skill(self.SKILL)
-        assert "--input-schema" in content or "--output-schema" in content
+        assert "--input-schema" in content and "--output-schema" in content
 
 
 # ── Workflow deletion warning (workflows-development) ───────────────────────
@@ -141,13 +148,43 @@ class TestWorkflowDeletionWarning:
         assert "dependent artifact" in content
 
     def test_alternatives_provided(self):
-        """Must provide safe alternatives (update in place, redeploy)."""
+        """Must direct the reader to update in place rather than recreate."""
         content = _read_skill(self.SKILL)
-        assert "update in place" in content.lower() or "edit" in content.lower()
-        assert "redeploy" in content or "deploy" in content
+        # Anchor on the specific instruction — "edit"/"deploy" appear all over
+        # this file for unrelated reasons and pass even without the warning.
+        assert "update in place" in content.lower()
 
     def test_old_delete_advice_removed(self):
         """Must NOT advise 'delete and re-create' as a fix for missing workflow_integration."""
         content = _read_skill(self.SKILL)
         # The old advice was exactly this sentence:
         assert "delete and re-create it with the appropriate flags" not in content
+
+
+# ── Cross-skill consistency ─────────────────────────────────────────────────
+
+
+class TestCrossSkillConsistency:
+    """Guard against the two skills giving opposite advice for one task.
+
+    An earlier draft of this branch had workflows-development saying to fix a
+    missing workflow_integration by editing the manifest and redeploying, while
+    functions-development said to recreate the function. Both load together for
+    workflow+function apps, so the contradiction was reachable.
+    """
+
+    FUNCTIONS = "skills/functions-development/SKILL.md"
+    WORKFLOWS = "skills/workflows-development/SKILL.md"
+
+    def test_neither_skill_claims_manifest_edit_adds_workflow_integration(self):
+        """Both skills must agree that recreation, not a manifest edit, is the fix."""
+        workflows = _read_skill(self.WORKFLOWS)
+        assert "add the `workflow_integration` block to the function's manifest entry and redeploy" \
+            not in workflows
+
+    def test_both_skills_point_at_creation_time_binding(self):
+        """Both must name the CLI flags as the binding mechanism."""
+        for skill in (self.FUNCTIONS, self.WORKFLOWS):
+            content = _read_skill(skill)
+            assert "--input-schema" in content or "--wf-expose" in content, \
+                f"{skill} should reference the creation-time flags"

--- a/tests/test_skill_content.py
+++ b/tests/test_skill_content.py
@@ -129,11 +129,11 @@ class TestWorkflowDeletionWarning:
                "name must be unique" in content
 
     def test_recovery_cost_explained(self):
-        """Must explain that recovery often requires deleting the entire app."""
+        """Must explain that recovery often requires a fresh app."""
         content = _read_skill(self.SKILL)
-        assert "delete the entire app" in content or \
-               "deleting the entire app" in content or \
-               "fresh app" in content
+        assert "fresh app" in content or \
+               "delete the entire app" in content or \
+               "deleting the entire app" in content
 
     def test_dependent_artifact_error_documented(self):
         """Must document the cascading 'dependent artifact failed' error."""


### PR DESCRIPTION
Addresses issues discovered during a real-world Fusion Health Insights app build where four problems were encountered that our skills should have prevented.

### Changes

**functions-falcon-api/SKILL.md** — NGSIEM query recipe
- Complete `NGSIEM.start_search()` / `get_search_status()` pattern with poll loop
- Documents the `search-all` repository requirement (specific repo names cause 403 at runtime)
- Clarifies class roles: `NGSIEM` = querying, `FoundryLogScale` = ingestion only
- Shows how to scope to a specific repo via `#repo=fusion` filter in query string
- Adds `humio-auth-proxy:read` to the scope reference table for queries
- Links the Tech Hub blog post as reference

**functions-development/SKILL.md** — Function I/O schema requirements
- New "Function I/O Schemas — Required at Creation Time" section
- Documents that `output_schema`/`input_schema` must be set at creation via `--input-schema`/`--output-schema` CLI flags
- Explains the consequence: functions without output_schema produce no visible output in Fusion workflow actions
- Clarifies that adding schemas to manifest after creation does NOT bind them
- Provides recovery steps (recreate function, update workflow references)

**workflows-development/SKILL.md** — Workflow deletion danger
- New "NEVER Delete and Recreate Workflows" section with exact error messages (`409 name must be unique`, `400 dependent artifact failed`)
- Removes old advice that recommended delete-and-recreate as a routine fix
- Documents safe alternatives (edit YAML in place, redeploy)
- Explains cascading failure and that recovery often requires a fresh app

**tests/test_skill_content.py** — 17 regression tests
- Ensures these hard-won lessons stay documented and are not accidentally removed
- Covers all three skill files with assertion-based content checks
