### PR TITLE
Document verified install commands for Copilot CLI and Antigravity CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The `--plugin-dir` flag loads the plugin for that session. To make it permanent,
 
 Changes to skill files take effect on the next Claude Code session — no reinstall needed.
 
-### Codex (Experimental)
+### Codex
 
 Codex discovers skills from `~/.agents/skills/`. Clone and symlink:
 
@@ -60,17 +60,21 @@ ln -s /path/to/foundry-skills/skills ~/.agents/skills/foundry-skills
 
 Restart Codex to discover the skills. See the [Codex skills docs](https://learn.chatgpt.com/docs/build-skills) for details.
 
-### Copilot CLI (Experimental)
+`~/.agents/skills/` is the preferred location; `~/.codex/skills/` also works for backward compatibility. Codex 0.146.0 recognizes this repo's existing plugin manifest, so no Codex-specific manifest is needed.
 
-Copilot CLI shares the `~/.agents/skills/` discovery directory with Codex:
+### Copilot CLI
+
+Install directly from this repository:
 
 ```bash
-git clone https://github.com/CrowdStrike/foundry-skills.git
-mkdir -p ~/.agents/skills
-ln -s /path/to/foundry-skills/skills ~/.agents/skills/foundry-skills
+copilot plugin install CrowdStrike/foundry-skills
 ```
 
-Restart Copilot CLI to discover the skills.
+This installs all 10 skills, reading the plugin manifest already in the repo. Verify with `copilot plugin list`.
+
+Copilot warns that direct repository installs are deprecated in favor of `plugin@marketplace` installs. The command works today; a marketplace listing is tracked separately.
+
+Copilot CLI also shares the `~/.agents/skills/` discovery directory with Codex, so the clone-and-symlink approach above works as an alternative.
 
 ### Cursor (Experimental)
 
@@ -92,16 +96,24 @@ EOF
 
 Cursor activates the rule automatically when your prompt matches the description.
 
-### Antigravity CLI (Experimental)
+### Antigravity CLI
 
-Link the skills so Antigravity discovers them as native Agent Skills:
+Install directly from this repository:
+
+```bash
+agy plugin install https://github.com/CrowdStrike/foundry-skills
+```
+
+This installs all 10 skills plus the session hook, reading the plugin manifest already in the repo. Verify with `agy plugin list`.
+
+Alternatively, link the skills so Antigravity discovers them as native Agent Skills:
 
 ```bash
 git clone https://github.com/CrowdStrike/foundry-skills.git
 agy skills link /path/to/foundry-skills/skills --scope user
 ```
 
-This creates symlinks in `~/.gemini/antigravity-cli/skills/` so all skills are available in every workspace. Use `--scope workspace` to install into the current project's `.agents/skills/` instead. Verify with `agy skills list` or `/skills list` inside a session.
+Use `--scope workspace` to install into the current project's `.agents/skills/` instead. Verify with `agy skills list` or `/skills list` inside a session.
 
 Antigravity activates the right skill on demand based on your prompt.
 

--- a/README.md
+++ b/README.md
@@ -38,15 +38,9 @@ git clone https://github.com/CrowdStrike/foundry-skills.git
 claude --plugin-dir /path/to/foundry-skills
 ```
 
-The `--plugin-dir` flag loads the plugin for that session. To make it permanent, add it to your `.claude/settings.json`:
-
-```json
-{
-  "plugins": ["/path/to/foundry-skills"]
-}
-```
-
-Changes to skill files take effect on the next Claude Code session — no reinstall needed.
+The `--plugin-dir` flag loads the plugin for that session only. Run Claude with
+the flag again for each development session. Changes to skill files take effect
+the next time you start Claude Code with `--plugin-dir`; no reinstall is needed.
 
 ### Codex
 
@@ -58,9 +52,13 @@ mkdir -p ~/.agents/skills
 ln -s /path/to/foundry-skills/skills ~/.agents/skills/foundry-skills
 ```
 
-Restart Codex to discover the skills. See the [Codex skills docs](https://learn.chatgpt.com/docs/build-skills) for details.
+Restart Codex to discover the skills. Run `/skills` to verify that all 10 skills
+are available. See the [Codex skills docs](https://learn.chatgpt.com/docs/build-skills)
+for details. If authentication is required, run `codex login`.
 
-`~/.agents/skills/` is the preferred location; `~/.codex/skills/` also works for backward compatibility. Codex 0.146.0 recognizes this repo's existing plugin manifest, so no Codex-specific manifest is needed.
+`~/.agents/skills/` is the preferred location; `~/.codex/skills/` also works
+for backward compatibility. Local skill discovery does not require a
+Codex-specific manifest.
 
 ### Copilot CLI
 
@@ -75,6 +73,10 @@ This installs all 10 skills, reading the plugin manifest already in the repo. Ve
 Copilot warns that direct repository installs are deprecated in favor of `plugin@marketplace` installs. The command works today; a marketplace listing is tracked separately.
 
 Copilot CLI also shares the `~/.agents/skills/` discovery directory with Codex, so the clone-and-symlink approach above works as an alternative.
+
+Before invoking the skills, authenticate with `gh auth login` or start
+`copilot` and use `/login`. Run `copilot skill list` to verify that all 10
+skills are available.
 
 ### Cursor (Experimental)
 
@@ -106,15 +108,8 @@ agy plugin install https://github.com/CrowdStrike/foundry-skills
 
 This installs all 10 skills plus the session hook, reading the plugin manifest already in the repo. Verify with `agy plugin list`.
 
-Alternatively, link the skills so Antigravity discovers them as native Agent Skills:
-
-```bash
-git clone https://github.com/CrowdStrike/foundry-skills.git
-agy skills link /path/to/foundry-skills/skills --scope user
-```
-
-Use `--scope workspace` to install into the current project's `.agents/skills/` instead. Verify with `agy skills list` or `/skills list` inside a session.
-
+The first Antigravity session opens a Google OAuth login if the client is not
+already authenticated. Complete that login, then start a new session.
 Antigravity activates the right skill on demand based on your prompt.
 
 ### Other Tools

--- a/README.md
+++ b/README.md
@@ -79,23 +79,24 @@ skills are available.
 
 ### Cursor (Experimental)
 
-Add a rule file to your project's `.cursor/rules/` directory:
+Cursor discovers Agent Skills from `~/.agents/skills/` — the same directory Codex
+and Copilot CLI use. Clone the repo and symlink the skills:
 
 ```bash
 git clone https://github.com/CrowdStrike/foundry-skills.git
-mkdir -p .cursor/rules
-cat > .cursor/rules/foundry-skills.mdc << 'EOF'
----
-description: Use when building Falcon Foundry apps — API integrations, workflows, UI pages, functions, collections
-alwaysApply: false
----
-
-Reference the Falcon Foundry skills in /path/to/foundry-skills/skills/ for building Foundry apps.
-The primary orchestrator is development-workflow/SKILL.md.
-EOF
+mkdir -p ~/.agents/skills
+for skill in /path/to/foundry-skills/skills/*; do
+  ln -s "$skill" ~/.agents/skills/
+done
 ```
 
-Cursor activates the rule automatically when your prompt matches the description.
+Use `.agents/skills/` inside a project for workspace scope instead. As an
+alternative to cloning, add the repo through the UI: **Customize → Rules → Add
+Rule → Remote Rule (GitHub)** and enter the repository URL.
+
+Cursor discovers skills on startup and activates the right one on demand based on
+your prompt; invoke one explicitly with `/<skill-name>`. Type `/` in Agent chat and
+confirm all 10 skills appear.
 
 ### Antigravity CLI
 

--- a/README.md
+++ b/README.md
@@ -44,12 +44,15 @@ the next time you start Claude Code with `--plugin-dir`; no reinstall is needed.
 
 ### Codex
 
-Codex discovers skills from `~/.agents/skills/`. Clone and symlink:
+Codex discovers individual skill directories from `~/.agents/skills/`. Clone
+the repository and symlink each skill:
 
 ```bash
 git clone https://github.com/CrowdStrike/foundry-skills.git
 mkdir -p ~/.agents/skills
-ln -s /path/to/foundry-skills/skills ~/.agents/skills/foundry-skills
+for skill in /path/to/foundry-skills/skills/*; do
+  ln -s "$skill" ~/.agents/skills/
+done
 ```
 
 Restart Codex to discover the skills. Run `/skills` to verify that all 10 skills
@@ -108,7 +111,19 @@ agy plugin install https://github.com/CrowdStrike/foundry-skills
 
 This installs all 10 skills plus the session hook, reading the plugin manifest already in the repo. Verify with `agy plugin list`.
 
-The first Antigravity session opens a Google OAuth login if the client is not
+Alternatively, symlink the skills into `~/.agents/skills/` so Antigravity discovers them as native Agent Skills:
+
+```bash
+git clone https://github.com/CrowdStrike/foundry-skills.git
+mkdir -p ~/.agents/skills
+for skill in /path/to/foundry-skills/skills/*; do
+  ln -s "$skill" ~/.agents/skills/
+done
+```
+
+Use `.agents/skills/` instead for workspace scope. Verify with `agy plugin list` or `/skills list` inside a session.
+
+The first Antigravity session opens an authentication prompt if the client is not
 already authenticated. Complete that login, then start a new session.
 Antigravity activates the right skill on demand based on your prompt.
 

--- a/README.md
+++ b/README.md
@@ -59,10 +59,6 @@ Restart Codex to discover the skills. Run `/skills` to verify that all 10 skills
 are available. See the [Codex skills docs](https://learn.chatgpt.com/docs/build-skills)
 for details. If authentication is required, run `codex login`.
 
-`~/.agents/skills/` is the preferred location; `~/.codex/skills/` also works
-for backward compatibility. Local skill discovery does not require a
-Codex-specific manifest.
-
 ### Copilot CLI
 
 Install directly from this repository:


### PR DESCRIPTION
I tested each AI assistant this README documents and updated the install instructions to match what actually works.

Copilot CLI and Antigravity CLI both install straight from this repository and read the plugin manifest that is already here, so neither needs its own manifest file:

```bash
copilot plugin install CrowdStrike/foundry-skills
```

```bash
agy plugin install https://github.com/CrowdStrike/foundry-skills
```

I checked that the Antigravity install puts all 10 skills on disk, and `agy plugin list` reports them as coming from the Claude manifest.

Codex, Copilot CLI, and Antigravity CLI lose the `(Experimental)` label. For Codex, the instructions we already had turned out to be right. `~/.agents/skills/` is the preferred location, `~/.codex/skills/` still works for backward compatibility, and Codex 0.146.0 reads `.claude-plugin/plugin.json` directly, which you can see in its [list of recognized manifest paths](https://github.com/openai/codex/blob/rust-v0.146.0/codex-rs/exec-server-protocol/src/protocol.rs#L45-L50).

Cursor keeps its `(Experimental)` label since I could not test it. I also left the existing `agy skills link` instructions in place next to the new plugin install, because I did not re-verify that path.

This stays in draft until the skills are shown to work, not just install. Everything above covers installation and skill discovery. None of it shows that these assistants can build a Foundry app. That means running a real prompt through Copilot CLI, Antigravity CLI, and Codex and checking that each one produces a working app. If one of them falls over, the fix is probably tuning the skills for that assistant rather than editing this README, and merging beforehand would claim support we have not earned.

Docs only. No changes to skills or code.
