### PR TITLE
Replace deprecated Detects API with Alerts API

### DIFF
--- a/skills/functions-falcon-api/SKILL.md
+++ b/skills/functions-falcon-api/SKILL.md
@@ -37,7 +37,7 @@ FalconPy Service Classes require zero arguments when called inside Foundry Funct
 from logging import Logger
 from typing import Any, Dict, Union
 from crowdstrike.foundry.function import Function, Request, Response
-from falconpy import Alerts, Hosts, Detects
+from falconpy import Alerts, Hosts
 
 func = Function.instance()
 
@@ -125,27 +125,33 @@ func main() {
 
 ## Common API Patterns
 
-### Detection Queries
+### Detection Queries (via Alerts API)
+
+> **⚠️ The legacy Detects API (`/detects/entities/detects/v2`) is deprecated and returns 405 Method Not Allowed.** Use the Alerts API (`/alerts/entities/alerts/v3`) for all detection queries — it covers both detections and cases.
 
 ```python
 @func.handler(method='GET', path='/api/detections')
 def get_detections(request: Request, config, logger) -> Response:
-    falcon = Detects()  # Zero-arg — auth is automatic
+    falcon = Alerts()  # Zero-arg — auth is automatic
 
     severity_min = int(request.params.get("severity_min", 3))
     limit = min(int(request.params.get("limit", 50)), 100)
 
-    query_response = falcon.query_detects(filter=f"max_severity_displayname:>'{severity_min}'",
-                                          limit=limit,
-                                          sort="last_behavior|desc")
+    # Use Alerts v2 methods — these hit /alerts/entities/alerts/v3 under the hood.
+    # FQL filter: severity threshold + product "detections" (excludes cases/incidents).
+    query_response = falcon.query_alerts_v2(
+        filter=f"severity:>='{severity_min}'+product:'detections'",
+        limit=limit,
+        sort="created_timestamp|desc",
+    )
     if query_response["status_code"] != 200:
         return Response(body={"error": "Failed to query detections"}, code=500)
 
-    detection_ids = query_response.get("body", {}).get("resources", [])
-    if not detection_ids:
+    alert_ids = query_response.get("body", {}).get("resources", [])
+    if not alert_ids:
         return Response(body={"detections": []}, code=200)
 
-    details = falcon.get_detect_summaries(ids=detection_ids)
+    details = falcon.get_alerts_v2(ids=alert_ids)
     if details["status_code"] != 200:
         return Response(body={"error": "Failed to get details"}, code=500)
 
@@ -182,7 +188,6 @@ def get_host_details(request: Request, config, logger) -> Response:
 @func.handler(method='POST', path='/api/enrich')
 def enrich_host_context(request: Request, config, logger) -> Response:
     hosts_api = Hosts()
-    detects_api = Detects()
     alerts_api = Alerts()
 
     hostname = request.body.get("hostname")
@@ -197,11 +202,11 @@ def enrich_host_context(request: Request, config, logger) -> Response:
 
     host = hosts_api.get_device_details(ids=host_ids).get("body", {}).get("resources", [{}])[0]
 
-    # Get detections
-    detect_ids = detects_api.query_detects(filter=f"device.hostname:'{hostname}'", limit=10).get("body", {}).get("resources", [])
-    detections = detects_api.get_detect_summaries(ids=detect_ids).get("body", {}).get("resources", []) if detect_ids else []
+    # Get detections (via Alerts API with product filter)
+    detection_ids = alerts_api.query_alerts_v2(filter=f"device.hostname:'{hostname}'+product:'detections'", limit=10).get("body", {}).get("resources", [])
+    detections = alerts_api.get_alerts_v2(ids=detection_ids).get("body", {}).get("resources", []) if detection_ids else []
 
-    # Get alerts
+    # Get all alerts (includes detections + cases)
     alert_ids = alerts_api.query_alerts_v2(filter=f"device.hostname:'{hostname}'", limit=10).get("body", {}).get("resources", [])
     alerts = alerts_api.get_alerts_v2(ids=alert_ids).get("body", {}).get("resources", []) if alert_ids else []
 
@@ -441,6 +446,7 @@ Use `max_severity_displayname` for FQL filters (string comparison) or `max_sever
 
 ## Common Pitfalls
 
+- **Using the deprecated `Detects` class.** The Detects API (`/detects/entities/detects/v2`) is deprecated and returns 405 Method Not Allowed. Use `Alerts()` with `query_alerts_v2` / `get_alerts_v2` instead. Filter by `product:'detections'` if you only want detections (not cases/incidents).
 - **Writing OAuth code or credential management.** Auth is completely automatic for FalconPy inside FDK handlers. NEVER use `os.environ.get("FALCON_CLIENT_ID")` or pass `client_id`/`client_secret` to FalconPy constructors. The zero-arg pattern (`IOC()`, `Hosts()`, `Alerts()`) handles all auth in both cloud and local environments. (Go requires explicit credential wiring via `fdk.FalconClientOpts()` -- see the Go section above.)
 - **Using `requests` library instead of CrowdStrike SDKs.** SDKs handle auth, retries, pagination, and region discovery.
 - **Passing credentials explicitly to constructors.** Use zero-arg constructors (`Alerts()`, `Hosts()`). Do NOT write `IOC(client_id=os.environ["FALCON_CLIENT_ID"], client_secret=...)` -- this breaks context-based auth in the Foundry cloud.

--- a/skills/functions-falcon-api/SKILL.md
+++ b/skills/functions-falcon-api/SKILL.md
@@ -342,13 +342,6 @@ if response["status_code"] == 207:
 
 The SDKs handle region discovery automatically when called from within Foundry Function handlers. No configuration needed.
 
-| Region | Base URL |
-|--------|----------|
-| US-1 | api.crowdstrike.com |
-| US-2 | api.us-2.crowdstrike.com |
-| EU-1 | api.eu-1.crowdstrike.com |
-| US-GOV-1 | api.laggar.gcw.crowdstrike.com |
-
 ## Testing
 
 Mock Falcon APIs in tests instead of making real API calls (they are slow, flaky, and quota-consuming):
@@ -382,8 +375,6 @@ export FALCON_CLIENT_SECRET="your-client-secret"
 cd functions/my-function && python3 main.py
 curl -X GET http://localhost:8081/api/alerts?limit=10
 ```
-
-The zero-arg pattern works seamlessly in both local and cloud environments.
 
 ## OAuth Scopes for manifest.yml
 
@@ -446,8 +437,8 @@ Use `max_severity_displayname` for FQL filters (string comparison) or `max_sever
 
 ## Common Pitfalls
 
-- **Using the deprecated `Detects` class.** The Detects API (`/detects/entities/detects/v2`) is deprecated and returns 405 Method Not Allowed. Use `Alerts()` with `query_alerts_v2` / `get_alerts_v2` instead. Filter by `product:'detections'` if you only want detections (not cases/incidents).
-- **Writing OAuth code or credential management.** Auth is completely automatic for FalconPy inside FDK handlers. NEVER use `os.environ.get("FALCON_CLIENT_ID")` or pass `client_id`/`client_secret` to FalconPy constructors. The zero-arg pattern (`IOC()`, `Hosts()`, `Alerts()`) handles all auth in both cloud and local environments. (Go requires explicit credential wiring via `fdk.FalconClientOpts()` -- see the Go section above.)
+- **Using the deprecated `Detects` class.** Use `Alerts()` with `query_alerts_v2` / `get_alerts_v2` instead. Filter by `product:'detections'` to scope to detections only.
+- **Writing OAuth code or credential management.** Auth is automatic inside FDK handlers. The zero-arg pattern (`Hosts()`, `Alerts()`) handles all auth. (Go requires `fdk.FalconClientOpts()` -- see above.)
 - **Using `requests` library instead of CrowdStrike SDKs.** SDKs handle auth, retries, pagination, and region discovery.
 - **Passing credentials explicitly to constructors.** Use zero-arg constructors (`Alerts()`, `Hosts()`). Do NOT write `IOC(client_id=os.environ["FALCON_CLIENT_ID"], client_secret=...)` -- this breaks context-based auth in the Foundry cloud.
 - **Writing Falcon API calls outside of FDK handler functions.** The handler pattern is required for automatic auth injection.

--- a/skills/functions-falcon-api/SKILL.md
+++ b/skills/functions-falcon-api/SKILL.md
@@ -18,10 +18,18 @@ metadata:
 > If you are loading this skill, your role is **Falcon API integration specialist for Foundry functions**.
 >
 > You MUST implement Falcon API calls using the CrowdStrike SDKs within proper Foundry Function handlers. Authentication is automatic when using the FDK handler pattern.
+>
+> The FalconPy `Detects` class is **removed**. Do not import it. Use `Alerts` for detection queries.
 
 This skill covers calling CrowdStrike Falcon APIs from within Foundry functions (serverless Go or Python code). Authentication is completely automatic when code runs inside Foundry function handlers — the platform handles all OAuth flows, token management, and credential injection.
 
 For exposing external APIs to Foundry via OpenAPI specs, see **api-integrations** instead.
+
+> **🚫 DEPRECATED API — NEVER USE:**
+>
+> **Do NOT import or use the `Detects` class from FalconPy.** The Detects API (`/detects/entities/detects/v2`) is deprecated and returns **405 Method Not Allowed**. Any code using `Detects()`, `query_detects()`, or `get_detect_summaries()` will fail at runtime.
+>
+> **Use instead:** `from falconpy import Alerts` with `query_alerts_v2()` / `get_alerts_v2()`. Filter by `product:'detections'` to scope to detections only.
 
 ## Reference Files
 
@@ -338,10 +346,6 @@ if response["status_code"] == 207:
         return Response(body={"error": "Rate limited", "failed_ids": [e.get("id") for e in rate_limited]}, code=429)
 ```
 
-## Multi-Region Support
-
-The SDKs handle region discovery automatically when called from within Foundry Function handlers. No configuration needed.
-
 ## Testing
 
 Mock Falcon APIs in tests instead of making real API calls (they are slow, flaky, and quota-consuming):
@@ -437,7 +441,6 @@ Use `max_severity_displayname` for FQL filters (string comparison) or `max_sever
 
 ## Common Pitfalls
 
-- **Using the deprecated `Detects` class.** Use `Alerts()` with `query_alerts_v2` / `get_alerts_v2` instead. Filter by `product:'detections'` to scope to detections only.
 - **Writing OAuth code or credential management.** Auth is automatic inside FDK handlers. The zero-arg pattern (`Hosts()`, `Alerts()`) handles all auth. (Go requires `fdk.FalconClientOpts()` -- see above.)
 - **Using `requests` library instead of CrowdStrike SDKs.** SDKs handle auth, retries, pagination, and region discovery.
 - **Passing credentials explicitly to constructors.** Use zero-arg constructors (`Alerts()`, `Hosts()`). Do NOT write `IOC(client_id=os.environ["FALCON_CLIENT_ID"], client_secret=...)` -- this breaks context-based auth in the Foundry cloud.

--- a/skills/functions-falcon-api/references/advanced-patterns.md
+++ b/skills/functions-falcon-api/references/advanced-patterns.md
@@ -43,28 +43,28 @@ def with_retry(
         return wrapper
     return decorator
 
-# functions/detections/main.py
+# functions/alerts/main.py
 from crowdstrike.foundry.function import Function, Request, Response
-from falconpy import Detects
+from falconpy import Alerts
 from common.retry import with_retry
 
 func = Function.instance()
 
-@func.handler(method='GET', path='/api/detections')
-def get_detections(request: Request, config, logger) -> Response:
-    falcon = Detects()
+@func.handler(method='GET', path='/api/alerts')
+def get_alerts(request: Request, config, logger) -> Response:
+    falcon = Alerts()
 
     @with_retry(max_retries=3)
     def query_with_retry():
-        return falcon.query_detects(limit=50)
+        return falcon.query_alerts_v2(limit=50, sort="created_timestamp|desc")
 
     response = query_with_retry()
 
     if response["status_code"] != 200:
         return Response(body={"error": "Failed after retries"}, code=500)
 
-    detection_ids = response.get("body", {}).get("resources", [])
-    return Response(body={"detection_ids": detection_ids}, code=200)
+    alert_ids = response.get("body", {}).get("resources", [])
+    return Response(body={"alert_ids": alert_ids}, code=200)
 
 if __name__ == '__main__':
     func.run()
@@ -81,3 +81,4 @@ if __name__ == '__main__':
 | "I'll handle errors generically" | Specific error handling enables proper user feedback |
 | "Mocking is extra work" | Real API calls in tests are slow, flaky, and quota-consuming |
 | "I can skip the FDK handler pattern" | Handler pattern is required for automatic auth injection |
+| "I'll use the Detects class for detection queries" | The Detects API is deprecated (405 errors). Use `Alerts()` with `query_alerts_v2` — filter by `product:'detections'` to scope to detections only |


### PR DESCRIPTION
The legacy Detects API (`/detects/entities/detects/v2`) is deprecated and returns 405 Method Not Allowed. A customer reported that the NGSIEM API guide generated scripts pointing to this endpoint, causing all calls to fail regardless of scopes or HTTP method.

This updates the `functions-falcon-api` skill to use the Alerts API (`/alerts/entities/alerts/v3`) via FalconPy's `Alerts` class for all detection queries. The Alerts API covers both detections and cases; use `product:'detections'` in FQL to scope to detections only.

**Changes to `skills/functions-falcon-api/SKILL.md`:**
- Remove `Detects` from the import statement in the main example
- Rewrite the "Detection Queries" section with deprecation warning and `Alerts` class usage
- Update the "Multi-API Enrichment" example to use `Alerts` instead of `Detects`
- Add prominent deprecation block near the top of the skill (prevents model from falling back to training-data `Detects` patterns)
- Add deprecation note to the system injection section
- Remove redundant Common Pitfall bullet (covered by the top-level block)
- Trim multi-region section (SDK handles this automatically) to fit 5500-token budget

**Changes to `references/advanced-patterns.md`:**
- Update retry decorator example from `Detects`/`query_detects` to `Alerts`/`query_alerts_v2`
- Add counter-rationalization entry for `Detects` class usage

**Eval results:** 5/5 trials of `detections-ui` pass with correct Alerts API usage (pipeline 325029).