### PR TITLE
Add US-3 region to cloud-region documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.5.0] - TBD
+
+### Added
+
+- US-3 cloud region to the cloud-region documentation: added `us-3` to the `FOUNDRY_CLOUD_REGION` value lists (headless-operation reference, e2e-testing env var table) and the multi-cloud deployment section. Foundry CLI 2.0.2 added US-3 support; the base URL (`api.us-3.crowdstrike.com`) is in FalconPy as of v1.6.4.
+
 ## [1.4.1] - 2026-08-07
 
 ### Fixed

--- a/skills/development-workflow/SKILL.md
+++ b/skills/development-workflow/SKILL.md
@@ -250,7 +250,7 @@ foundry apps release --change-type Patch --deployment-id <id> --notes "Release n
 
 ## Multi-Cloud Deployment
 
-To deploy the same app to multiple clouds (US-1, US-2, EU-1, etc.):
+To deploy the same app to multiple clouds (US-1, US-2, US-3, EU-1, etc.):
 
 1. **Strip all IDs** before deploying to a new cloud — IDs are cloud-specific:
    ```bash

--- a/skills/development-workflow/references/headless-operation.md
+++ b/skills/development-workflow/references/headless-operation.md
@@ -14,7 +14,7 @@ Set these environment variables to bypass local credential storage entirely:
 export FOUNDRY_API_CLIENT_ID="<your-api-client-id>"
 export FOUNDRY_API_CLIENT_SECRET="<your-api-client-secret>"
 export FOUNDRY_CID="<your-customer-id>"
-export FOUNDRY_CLOUD_REGION="us-1"  # us-1, us-2, eu-1, us-gov-1, us-gov-2
+export FOUNDRY_CLOUD_REGION="us-1"  # us-1, us-2, us-3, eu-1, us-gov-1, us-gov-2
 ```
 
 Environment variables override local credentials. No `foundry login` needed.

--- a/skills/e2e-testing/SKILL.md
+++ b/skills/e2e-testing/SKILL.md
@@ -376,7 +376,7 @@ The sample apps use a shared `e2e.yml` workflow pattern. Rather than duplicating
 | `FOUNDRY_API_CLIENT_ID` | Foundry CLI authentication |
 | `FOUNDRY_API_CLIENT_SECRET` | Foundry CLI authentication |
 | `FOUNDRY_CID` | CrowdStrike Customer ID |
-| `FOUNDRY_CLOUD_REGION` | Cloud region (us-1, us-2, eu-1) |
+| `FOUNDRY_CLOUD_REGION` | Cloud region (us-1, us-2, us-3, eu-1) |
 | `FALCON_USERNAME` | Falcon console login for Playwright |
 | `FALCON_PASSWORD` | Falcon console password |
 | `FALCON_AUTH_SECRET` | TOTP secret for 2FA |


### PR DESCRIPTION
Documents the US-3 cloud across the region references. Foundry CLI 2.0.2 added US-3 support, and the US-3 base URL (`api.us-3.crowdstrike.com`) is in FalconPy as of v1.6.4.

Changes:
- `skills/development-workflow/references/headless-operation.md` — added `us-3` to the `FOUNDRY_CLOUD_REGION` value list.
- `skills/development-workflow/SKILL.md` — added US-3 to the multi-cloud deployment section.
- `skills/e2e-testing/SKILL.md` — added `us-3` to the `FOUNDRY_CLOUD_REGION` env var description.

Documentation only; region slugs pass straight through to the CLI.

Draft while US-3 completes its rollout.