### PR TITLE
Update NGSIEM start_search keyword guidance for FalconPy 1.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - **Agent Plugins manifest** — A root `plugin.json` conforming to the [Agent Plugins](https://agent-plugins.org) 1.0.0 spec, so any conforming client can discover the plugin alongside the existing Claude and Codex manifests. CI validates it and `release.sh` bumps its version with the others.
 - US-3 cloud region to the cloud-region documentation: added `us-3` to the `FOUNDRY_CLOUD_REGION` value lists (headless-operation reference, e2e-testing env var table) and the multi-cloud deployment section. Foundry CLI 2.0.2 added US-3 support; the base URL (`api.us-3.crowdstrike.com`) is in FalconPy as of v1.6.4.
 
+### Changed
+
+- **NGSIEM `start_search` keyword guidance updated for FalconPy 1.6.5** — The `search=` keyword remains the recommended approach (works on all versions), but the explanation now notes that `body=` was fixed in FalconPy 1.6.5 ([#1497](https://github.com/CrowdStrike/falconpy/pull/1497)). Since FalconPy is unpinned, `search=` is still the safe default.
+
 ### Fixed
 
 - **Sub-skill routing survives a single-entry-point install** — `development-workflow` now documents that sub-skills live beside it on disk as `../<name>/SKILL.md`, and how to handle a capability-level request that lands on the orchestrator: read the sub-skill from disk first, then skip straight to the CLI command when `manifest.yml` already exists. Assistants that register only the orchestrator no longer have to infer this. The orchestrator's trigger description is unchanged, so skill selection on a fully-registered install behaves exactly as before.

--- a/skills/functions-falcon-api/SKILL.md
+++ b/skills/functions-falcon-api/SKILL.md
@@ -226,7 +226,8 @@ def run_logscale_query(ngsiem, query_string, start, end, logger, max_wait=40):
     "now") or epoch-millisecond integers.
     """
     payload = {"queryString": query_string, "start": start, "end": end, "isLive": False}
-    # Must be search=, not body= — see the keyword gotcha below.
+    # Pass the payload as search= — works on all FalconPy versions (body= only
+    # works on 1.6.5+; see the keyword note below).
     started = ngsiem.start_search(repository=REPO, search=payload)
 
     if not isinstance(started, dict) or started.get("status_code", 500) >= 300:
@@ -277,7 +278,7 @@ if __name__ == '__main__':
 
 ### The `search=` Keyword Gotcha
 
-**CRITICAL:** Pass the query payload as `search=`, not `body=`. FalconPy's guard reads only `kwargs.get("search")`, so `body=` returns a local error without issuing a request. The docstring lists `body` as accepted, but the guard ignores it ([falconpy#1491](https://github.com/CrowdStrike/falconpy/issues/1491)).
+**Use `search=`.** It works on every FalconPy version. `body=` was silently ignored before 1.6.5 ([falconpy#1491](https://github.com/CrowdStrike/falconpy/issues/1491), fixed in [#1497](https://github.com/CrowdStrike/falconpy/pull/1497)). Since FalconPy is unpinned, `search=` is the safe default.
 
 Response keys are asymmetric: `start_search` renames its payload to `resources` (read `started["resources"]["id"]`), while `get_search_status` does not (read `status["body"]`).
 

--- a/skills/functions-falcon-api/SKILL.md
+++ b/skills/functions-falcon-api/SKILL.md
@@ -226,8 +226,7 @@ def run_logscale_query(ngsiem, query_string, start, end, logger, max_wait=40):
     "now") or epoch-millisecond integers.
     """
     payload = {"queryString": query_string, "start": start, "end": end, "isLive": False}
-    # Pass the payload as search= — works on all FalconPy versions (body= only
-    # works on 1.6.5+; see the keyword note below).
+    # Must be search=, not body= — see the keyword gotcha below.
     started = ngsiem.start_search(repository=REPO, search=payload)
 
     if not isinstance(started, dict) or started.get("status_code", 500) >= 300:


### PR DESCRIPTION
FalconPy 1.6.5 fixed the bug where `body=` was silently ignored by `NGSIEM.start_search()` (#1497, closes #1491). The skill previously stated `body=` is broken; it now notes that `body=` works on 1.6.5+ but recommends `search=` as the version-agnostic default since FalconPy is unpinned.

No example code changed. `search=` remains in all examples.