### PR TITLE
release.sh: recognize anchored links in the bundle link check

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -158,8 +158,8 @@ build_bundle() {
   local missing
   missing=$(cd "$work" && find skills -name '*.md' | while read -r f; do
     d=$(dirname "$f")
-    grep -ohE '\]\((\.\./)*[A-Za-z0-9_./-]+\.(md|py|sh|json|ya?ml)\)' "$f" 2>/dev/null \
-      | sed 's/^](//; s/)$//' | while read -r link; do
+    grep -ohE '\]\((\.\./)*[A-Za-z0-9_./-]+\.(md|py|sh|json|ya?ml)(#[^)]*)?\)' "$f" 2>/dev/null \
+      | sed 's/^](//; s/)$//; s/#.*$//' | while read -r link; do
         target=$(python3 -c 'import os,sys; print(os.path.normpath(os.path.join(sys.argv[1], sys.argv[2])))' "$d" "$link")
         [[ -e "$target" ]] || printf '%s -> %s\n' "$f" "$link"
       done


### PR DESCRIPTION
`release.sh --bundle` resolves every relative path a skill references to confirm it lives in the archive, but the extraction regex required the path to be immediately followed by `)`. A markdown link carrying a `#section` anchor — `](references/foo.md#heading)` — never matched, so a bundled file referenced only through an anchored link could be dropped from the archive without the check noticing.

The regex now allows an optional `#anchor` and the `sed` strips it before resolving, so the target path is checked either way. foundry already has such an anchored link in a skill (`pagination-patterns.md#the-0-gotcha`).

Verified: `bash -n` and `shellcheck` clean; `./release.sh --bundle HEAD` still passes with all referenced paths resolving; on a fixture, `ref.md#heading` resolves to `ref.md` while a genuinely missing target is still reported.