### PR TITLE
Strip query strings from relative link targets in the CI check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -206,7 +206,7 @@ jobs:
                   continue
               for lineno, line in enumerate(path.read_text(errors='ignore').splitlines(), 1):
                   for match in pattern.finditer(line):
-                      target = match.group(1).split('#')[0].strip()
+                      target = match.group(1).split('#')[0].split('?')[0].strip()
                       if not target or target.startswith(('http', 'mailto:', '/')):
                           continue
                       if not (path.parent / target).exists():


### PR DESCRIPTION
A link like `(file.md?foo=bar)` would try to resolve `file.md?foo=bar` as a filename and fail. Root-relative links (`/images/...`) were already skipped by the `startswith` check, so this was latent rather than failing today, but splitting on `?` before resolution makes the check correct for both cases. Found by the fusion-skills agent when mirroring this check into their CI.