### PR TITLE
docs: point Cursor install at the live marketplace listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ AI coding assistant skills for building [CrowdStrike Falcon Foundry](https://www
 | Claude Code | `/plugin install crowdstrike-falcon-foundry` | [Anthropic](https://claude.com/plugins/crowdstrike-falcon-foundry) |
 | Codex | `codex plugin add crowdstrike-falcon-foundry` | [OpenAI](https://chatgpt.com/plugins) (pending) |
 | Copilot CLI | `copilot plugin install CrowdStrike/foundry-skills` | [GitHub](https://github.com/marketplace?type=copilot-plugins) |
-| Cursor | `/add-plugin crowdstrike-falcon-foundry` | [Cursor](https://cursor.com/marketplace) (pending) |
+| Cursor | `/plugins` (CLI) or `/add-plugin crowdstrike-falcon-foundry` (IDE) | [Cursor](https://cursor.com/marketplace/crowdstrike/crowdstrike-falcon-foundry) |
 | Antigravity CLI | `agy plugin install https://github.com/CrowdStrike/foundry-skills` | [Google](https://antigravity.google/docs/plugins) |
 
 All five assistants have been verified end to end: the skills were loaded from a local clone, then used to build and deploy an app to a live Falcon Foundry tenant from the example prompt below.


### PR DESCRIPTION
Cursor now lists the plugin in its marketplace (`cursor.com/marketplace/crowdstrike/crowdstrike-falcon-foundry`), so the install table drops "(pending)" and deep-links to the listing.

It also corrects the Cursor CLI install command. The interactive install path is `/plugins` — confirmed by the Cursor CLI itself ("use /plugins in interactive mode to install plugins from this marketplace") and by a live install (plugin cached under `cursor-public` at the v1.5.0 tag). `/plugin` (singular) is only the marketplace-management namespace (`/plugin marketplace list | add`), not an install command. The editor `/add-plugin <name>` command is unchanged.