### PR TITLE
docs: point Copilot install at the awesome-copilot listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ AI coding assistant skills for building [CrowdStrike Falcon Foundry](https://www
 |-----------|---------|-------------|
 | Claude Code | `/plugin install crowdstrike-falcon-foundry` | [Anthropic](https://claude.com/plugins/crowdstrike-falcon-foundry) |
 | Codex | `codex plugin add crowdstrike-falcon-foundry` | [OpenAI](https://chatgpt.com/plugins) (pending) |
-| Copilot CLI | `copilot plugin install CrowdStrike/foundry-skills` | [GitHub](https://github.com/marketplace?type=copilot-plugins) |
+| Copilot CLI | `copilot plugin install CrowdStrike/foundry-skills` | [GitHub](https://awesome-copilot.github.com/plugin/crowdstrike-falcon-foundry/) |
 | Cursor | `/plugins` (CLI) or `/add-plugin crowdstrike-falcon-foundry` (IDE) | [Cursor](https://cursor.com/marketplace/crowdstrike/crowdstrike-falcon-foundry) |
 | Antigravity CLI | `agy plugin install https://github.com/CrowdStrike/foundry-skills` | [Google](https://antigravity.google/docs/plugins) |
 


### PR DESCRIPTION
The Copilot CLI row in the install table linked its Marketplace column at the generic `github.com/marketplace?type=copilot-plugins` search. Searching that page for "crowdstrike" returns only CrowdStrike GitHub Actions (container image scan, Falconutil, FCS CLI, and a mock server); the `crowdstrike-falcon-foundry` Copilot plugin does not appear there at all, so the link sent readers to unrelated results.

This points the link instead at the plugin's [awesome-copilot listing page](https://awesome-copilot.github.com/plugin/crowdstrike-falcon-foundry/), where the plugin is actually published and discoverable, and which stays on a github.com domain. It also matches how the Cursor row already links to a specific listing rather than a search.

The install command is unchanged and verified: `copilot plugin install` accepts the `owner/repo` form (`CrowdStrike/foundry-skills`), and the plugin is listed in the Copilot CLI's default `awesome-copilot` marketplace (`copilot plugin marketplace browse awesome-copilot` shows it).