### PR TITLE
docs: document both Codex install paths (curated marketplace + ChatGPT /plugins)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,13 @@ AI coding assistant skills for building [CrowdStrike Falcon Foundry](https://www
 | Assistant | Command | Marketplace |
 |-----------|---------|-------------|
 | Claude Code | `/plugin install crowdstrike-falcon-foundry` | [Anthropic](https://claude.com/plugins/crowdstrike-falcon-foundry) |
-| Codex | `codex plugin add crowdstrike-falcon-foundry` | [OpenAI](https://chatgpt.com/plugins) (pending) |
+| Codex | `codex plugin add crowdstrike-falcon-foundry@openai-api-curated` | [OpenAI](https://chatgpt.com/plugins) |
 | Copilot CLI | `copilot plugin install CrowdStrike/foundry-skills` | [GitHub](https://awesome-copilot.github.com/plugin/crowdstrike-falcon-foundry/) |
 | Cursor | `/plugins` (CLI) or `/add-plugin crowdstrike-falcon-foundry` (IDE) | [Cursor](https://cursor.com/marketplace/crowdstrike/crowdstrike-falcon-foundry) |
 | Antigravity CLI | `agy plugin install https://github.com/CrowdStrike/foundry-skills` | [Google](https://antigravity.google/docs/plugins) |
+
+> [!NOTE]
+> **Codex** has two install paths depending on how you signed in. The command above installs from the curated CLI marketplace, which **API-key and Amazon Bedrock** sessions load. If you authenticated Codex with a **ChatGPT** account, that marketplace isn't loaded — instead run `/plugins` inside Codex, search for `crowdstrike`, and install from the results.
 
 All five assistants have been verified end to end: the skills were loaded from a local clone, then used to build and deploy an app to a live Falcon Foundry tenant from the example prompt below.
 


### PR DESCRIPTION
The Codex row showed a bare `codex plugin add crowdstrike-falcon-foundry` marked "(pending)", which the CLI rejects — it wants a `plugin@marketplace` source.

OpenAI confirmed the two Codex auth modes use **different marketplaces** today, with **no single command** that works across both, so both are documented:

- **API-key / Amazon Bedrock** — `codex plugin add crowdstrike-falcon-foundry@openai-api-curated` (the table command)
- **ChatGPT-authenticated** — `codex plugin add crowdstrike-falcon-foundry@openai-curated`, or `/plugins` → search `crowdstrike`

Rendered as a `[!NOTE]` admonition under the install table. Verified locally that `crowdstrike-falcon-foundry@openai-api-curated` resolves from the `CrowdStrike/foundry-skills` repo; the ChatGPT-side marketplace/command is per OpenAI Product.