### PR TITLE
docs: link the Codex OpenAI column to the specific plugin listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ AI coding assistant skills for building [CrowdStrike Falcon Foundry](https://www
 | Assistant | Command | Marketplace |
 |-----------|---------|-------------|
 | Claude Code | `/plugin install crowdstrike-falcon-foundry` | [Anthropic](https://claude.com/plugins/crowdstrike-falcon-foundry) |
-| Codex | `codex plugin add crowdstrike-falcon-foundry@openai-api-curated` | [OpenAI](https://chatgpt.com/plugins) |
+| Codex | `codex plugin add crowdstrike-falcon-foundry@openai-api-curated` | [OpenAI](https://chatgpt.com/plugins/plugins_6a8f6d7f7fac819191e3eba5a7a2e0df) |
 | Copilot CLI | `copilot plugin install CrowdStrike/foundry-skills` | [GitHub](https://awesome-copilot.github.com/plugin/crowdstrike-falcon-foundry/) |
 | Cursor | `/plugins` (CLI) or `/add-plugin crowdstrike-falcon-foundry` (IDE) | [Cursor](https://cursor.com/marketplace/crowdstrike/crowdstrike-falcon-foundry) |
 | Antigravity CLI | `agy plugin install https://github.com/CrowdStrike/foundry-skills` | [Google](https://antigravity.google/docs/plugins) |

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ AI coding assistant skills for building [CrowdStrike Falcon Foundry](https://www
 > **Codex** uses a different marketplace depending on how you signed in, so no single command works across both today:
 >
 > - **API-key / Amazon Bedrock** — the command above (`crowdstrike-falcon-foundry@openai-api-curated`).
-> - **ChatGPT-authenticated** — run `/plugins` and search for `crowdstrike` (the `openai-curated` CLI marketplace does not list these plugins yet).
+> - **ChatGPT-authenticated** — run `/plugins` and search for `crowdstrike`.
 
 All five assistants have been verified end to end: the skills were loaded from a local clone, then used to build and deploy an app to a live Falcon Foundry tenant from the example prompt below.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ AI coding assistant skills for building [CrowdStrike Falcon Foundry](https://www
 > **Codex** uses a different marketplace depending on how you signed in, so no single command works across both today:
 >
 > - **API-key / Amazon Bedrock** — the command above (`crowdstrike-falcon-foundry@openai-api-curated`).
-> - **ChatGPT-authenticated** — `codex plugin add crowdstrike-falcon-foundry@openai-curated`, or run `/plugins` and search for `crowdstrike`.
+> - **ChatGPT-authenticated** — run `/plugins` and search for `crowdstrike` (the `openai-curated` CLI marketplace does not list these plugins yet).
 
 All five assistants have been verified end to end: the skills were loaded from a local clone, then used to build and deploy an app to a live Falcon Foundry tenant from the example prompt below.
 

--- a/README.md
+++ b/README.md
@@ -27,10 +27,7 @@ AI coding assistant skills for building [CrowdStrike Falcon Foundry](https://www
 | Antigravity CLI | `agy plugin install https://github.com/CrowdStrike/foundry-skills` | [Google](https://antigravity.google/docs/plugins) |
 
 > [!NOTE]
-> **Codex** uses a different marketplace depending on how you signed in, so no single command works across both today:
->
-> - **API-key / Amazon Bedrock** — the command above (`crowdstrike-falcon-foundry@openai-api-curated`).
-> - **ChatGPT-authenticated** — run `/plugins` and search for `crowdstrike`.
+> **Codex** has two install paths depending on how you signed in. The command above installs from the curated CLI marketplace, which **API-key and Amazon Bedrock** sessions load. If you authenticated Codex with a **ChatGPT** account, that marketplace isn't loaded — instead run `/plugins` inside Codex, search for `crowdstrike`, and install from the results.
 
 All five assistants have been verified end to end: the skills were loaded from a local clone, then used to build and deploy an app to a live Falcon Foundry tenant from the example prompt below.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,10 @@ AI coding assistant skills for building [CrowdStrike Falcon Foundry](https://www
 | Antigravity CLI | `agy plugin install https://github.com/CrowdStrike/foundry-skills` | [Google](https://antigravity.google/docs/plugins) |
 
 > [!NOTE]
-> **Codex** has two install paths depending on how you signed in. The command above installs from the curated CLI marketplace, which **API-key and Amazon Bedrock** sessions load. If you authenticated Codex with a **ChatGPT** account, that marketplace isn't loaded — instead run `/plugins` inside Codex, search for `crowdstrike`, and install from the results.
+> **Codex** uses a different marketplace depending on how you signed in, so no single command works across both today:
+>
+> - **API-key / Amazon Bedrock** — the command above (`crowdstrike-falcon-foundry@openai-api-curated`).
+> - **ChatGPT-authenticated** — `codex plugin add crowdstrike-falcon-foundry@openai-curated`, or run `/plugins` and search for `crowdstrike`.
 
 All five assistants have been verified end to end: the skills were loaded from a local clone, then used to build and deploy an app to a live Falcon Foundry tenant from the example prompt below.
 


### PR DESCRIPTION
Point the Codex row's OpenAI marketplace link at the plugin's own chatgpt.com listing instead of the generic `/plugins` directory, matching how the Cursor and Copilot rows already link to their specific listings. No other changes — the install command and note are unchanged from main.